### PR TITLE
Naming fix, new config files

### DIFF
--- a/Tricca_AutoPipette/plates.py
+++ b/Tricca_AutoPipette/plates.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Type, Dict, ClassVar
 from abc import ABC, abstractmethod
 from well import Well
 from pydantic import BaseModel, conint, confloat, validator, ConfigDict, \
-                     field_validator, ValidationInfo
+                     field_validator, ValidationInfo, Field
 
 
 class NotAPlateTypeError(Exception):
@@ -34,14 +34,15 @@ class PlateParams(SmartDefaultModel):
     TODO Implement validators that set good defaults when None is set
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)  # Critical fix
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+
 
     plate_type: str
     well_template: Well
-    num_row: conint(ge=1) = 1
-    num_col: conint(ge=1) = 1
-    spacing_row: confloat(ge=0) = 0
-    spacing_col: confloat(ge=0) = 0
+    num_row: conint(ge=1)   = Field(1, alias="row")
+    num_col: conint(ge=1)   = Field(1, alias="col")
+    spacing_row: confloat(ge=0) = Field(0, alias="spacing_row")
+    spacing_col: confloat(ge=0) = Field(0, alias="spacing_col")
 
     @validator("plate_type")
     def validate_plate_type(cls, v, values):

--- a/Tricca_AutoPipette/tap_cmd_parsers.py
+++ b/Tricca_AutoPipette/tap_cmd_parsers.py
@@ -50,6 +50,12 @@ class TAPCmdParsers():
     parser_pipette.add_argument("--src_col", default=None, type=int)
     parser_pipette.add_argument("--dest_row", default=None, type=int)
     parser_pipette.add_argument("--dest_col", default=None, type=int)
+    parser_pipette.add_argument(
+    "--dispense_vol", "-d",
+    dest="disp_vol_ul",
+    default=None,
+    type=float,
+    )
 
     parser_run: Cmd2ArgumentParser = Cmd2ArgumentParser()
     parser_run.add_argument("filename", type=str)

--- a/Tricca_AutoPipette/tap_shell.py
+++ b/Tricca_AutoPipette/tap_shell.py
@@ -308,6 +308,7 @@ class TriccaAutoPipetteShell(Cmd):
         src: str = args.src
         dest: str = args.dest
         prewet: bool = args.prewet
+        disp_vol  = args.disp_vol_ul
         keep_tip: bool = args.keep_tip
         wiggle: bool = args.wiggle
         src_row: int = args.src_row
@@ -336,7 +337,7 @@ class TriccaAutoPipetteShell(Cmd):
                 "No coordinate set as TipBox.\n"
             rprint(err_msg)
             return
-        self._autopipette.pipette(vol_ul, src, dest,
+        self._autopipette.pipette(vol_ul, src, dest, disp_vol,
                                   src_row, src_col, dest_row, dest_col,
                                   keep_tip, prewet, wiggle)
         self.output_gcode([f"\n; Pipette {vol_ul} from {src} to {dest}\n"] +

--- a/Tricca_AutoPipette/tap_shell.py
+++ b/Tricca_AutoPipette/tap_shell.py
@@ -171,8 +171,9 @@ class TriccaAutoPipetteShell(Cmd):
                      append_header: bool = False) -> None:
         """Direct gcode output."""
         if self._append_gcode:
-            self._gcode_buffer + gcode
+            self._gcode_buffer.extend(gcode)
             self._gcode_buffer.append("\n")
+            return
         else:
             now = datetime.now()
             if filename is None:
@@ -401,23 +402,25 @@ class TriccaAutoPipetteShell(Cmd):
 
     @with_argparser(TAPCmdParsers.parser_run)
     def do_run(self, args):
-        """Run a protocol."""
-        filename: str = args.filename
-        cmds = []
-        file_path = self.PROTOCOL_PATH / filename
-        if (not file_path.exists()):
-            rprint(f"File: {file_path} does not exist")
+        filename = args.filename
+        proto = self.PROTOCOL_PATH / filename
+        if not proto.exists():
+            rprint(f"File not found: {proto}")
             return
-        with file_path.open("r") as fp:
-            for line in fp:
-                cmds.append(line)
+
+        lines = proto.read_text().splitlines()
         self._append_gcode = True
-        self.runcmds_plus_hooks(cmds,
+        self.runcmds_plus_hooks([ln + "\n" for ln in lines],
                                 add_to_history=False,
                                 stop_on_keyboard_interrupt=True)
         self._append_gcode = False
-        self.output_gcode(self._gcode_buffer, filename, append_header=True)
+
+        # now write & upload
+        self.output_gcode(self._gcode_buffer,
+                        Path(filename).with_suffix('.gcode').name,
+                        append_header=True)
         self._gcode_buffer = []
+
 
     def do_stop(self, args):
         """Send an emergency stop command to the pipette."""


### PR DESCRIPTION
I changed how the config parser looks for the col and row parameters on the config file. the previous version used 'num_row' and 'num_col' but was consistent throughout and did not work even changing the name on the config file to be the same.