### PR TITLE
Fix all 38 ruff preview-rule errors (issue #18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,8 @@ select = [
 
 ignore = [
     # Google-style docstrings
-    "D203",
-    "D213",
+    "incorrect-blank-line-before-class",
+    "multi-line-summary-second-line",
 ]
 
 external = ["DOC"]
@@ -141,7 +141,7 @@ allowed-confusables = ["×"]
 
 # ASCII-art banners: the "lines" are rows of a picture, and rich markup
 # tags make them long. Wrapping them would break the art.
-"src/tricca_autopipette/resources/string_constants.py" = ["E501"]
+"src/tricca_autopipette/resources/string_constants.py" = ["line-too-long"]
 
 
 [tool.ruff.lint.isort]

--- a/src/autopipette_kiosk/main.py
+++ b/src/autopipette_kiosk/main.py
@@ -119,10 +119,11 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         logger.error("Failed to connect to tapd control plane at %s", TAPD_CONTROL_URI)
     _control_client = client
 
-    yield
-
-    _control_client = None
-    await asyncio.to_thread(client.stop)
+    try:
+        yield
+    finally:
+        _control_client = None
+        await asyncio.to_thread(client.stop)
 
 
 app = FastAPI(title="AutoPipette Kiosk", lifespan=lifespan)
@@ -277,7 +278,7 @@ def _extract_error_type(exc: RuntimeError) -> str | None:
     return match.group(1) if match else None
 
 
-def _on_run_status_notification(params: Any) -> None:  # noqa: ANN401
+def _on_run_status_notification(params: Any) -> None:  # ruff:ignore[any-type]
     """Handle a `notify_run_status` push from the tapd control daemon.
 
     Args:
@@ -305,7 +306,7 @@ def _on_run_status_notification(params: Any) -> None:  # noqa: ANN401
         asyncio.run_coroutine_threadsafe(_broadcast_status(), _main_loop)
 
 
-def _on_breakpoint_notification(params: Any) -> None:  # noqa: ANN401
+def _on_breakpoint_notification(params: Any) -> None:  # ruff:ignore[any-type]
     """Handle a `notify_breakpoint` push from the tapd control daemon.
 
     Args:

--- a/src/tricca_autopipette/cli/remote_shell.py
+++ b/src/tricca_autopipette/cli/remote_shell.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 WEBSOCKET_TIMEOUT_SECONDS = 10
 
 
-def _as_dict(value: Any) -> dict[str, Any]:  # noqa: ANN401
+def _as_dict(value: Any) -> dict[str, Any]:  # ruff:ignore[any-type]
     """Narrow a loosely-typed JSON-RPC result/params value to a dict.
 
     Args:
@@ -124,7 +124,7 @@ class RemoteTapShell(Cmd):
 
     # ==================== notification handlers ====================
 
-    def _on_run_status(self, params: Any) -> None:  # noqa: ANN401
+    def _on_run_status(self, params: Any) -> None:  # ruff:ignore[any-type]
         """Show a live run-status update without disrupting the prompt.
 
         Args:
@@ -138,7 +138,7 @@ class RemoteTapShell(Cmd):
         message = notification.get("message", "")
         self.add_alert(msg=f"[run:{status}] {message}")
 
-    def _on_breakpoint(self, params: Any) -> None:  # noqa: ANN401
+    def _on_breakpoint(self, params: Any) -> None:  # ruff:ignore[any-type]
         """Prompt the user to answer a pending breakpoint.
 
         Args:
@@ -597,8 +597,8 @@ def _register_structured_commands() -> None:
 
         def handler(
             self: RemoteTapShell,
-            args: Any,  # noqa: ANN401
-            build_request: Any = build_request,  # noqa: ANN401
+            args: Any,  # ruff:ignore[any-type]
+            build_request: Any = build_request,  # ruff:ignore[any-type]
         ) -> None:
             # _call_and_print is a same-class method reached through a
             # properly-typed `self` -- pyright still flags it because this

--- a/src/tricca_autopipette/commands/base_command_set.py
+++ b/src/tricca_autopipette/commands/base_command_set.py
@@ -28,7 +28,7 @@ class TAPCommandSet(_CommandSetBase):
 
     @property
     def shell(self) -> TriccaAutoPipetteShell:
-        """Get the parent shell instance.
+        """The parent shell instance.
 
         Returns:
             The TriccaAutoPipetteShell instance.

--- a/src/tricca_autopipette/commands/tap_cmd_parsers.py
+++ b/src/tricca_autopipette/commands/tap_cmd_parsers.py
@@ -24,7 +24,7 @@ from tricca_autopipette.core.splits import LeftoverAction
 
 def args_from_namespace[ArgsT](
     args_cls: type[ArgsT],
-    ns: Any,  # noqa: ANN401
+    ns: Any,  # ruff:ignore[any-type]
 ) -> ArgsT:
     """Build one of this module's ``*Args`` dataclasses from a parsed Namespace.
 

--- a/src/tricca_autopipette/core/gcode_manager.py
+++ b/src/tricca_autopipette/core/gcode_manager.py
@@ -5,7 +5,7 @@ This module provides G-code generation, buffering, and file operations.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -73,7 +73,7 @@ class GCodeManager:
         return self._buffer.get_commands()  # Gets and clears
 
     @contextmanager
-    def batch_mode(self) -> Iterator[GCodeManager]:
+    def batch_mode(self) -> Generator[GCodeManager]:
         """Context manager for batch G-code generation.
 
         Yields:

--- a/src/tricca_autopipette/core/pipette_models.py
+++ b/src/tricca_autopipette/core/pipette_models.py
@@ -331,7 +331,7 @@ class PipetteSyringeKinematics(BaseModel):
         description="Air drawn after the liquid, to stop it dripping (μL)",
     )
 
-    def model_post_init(self, __context: Any) -> None:  # noqa: ANN401
+    def model_post_init(self, __context: Any) -> None:  # ruff:ignore[any-type]
         """Validate calibration data after initialization.
 
         Raises:
@@ -520,7 +520,7 @@ class LiquidProfile(BaseModel):
         description="Corresponding motor steps (overrides pipette default)",
     )
 
-    def model_post_init(self, __context: Any) -> None:  # noqa: ANN401
+    def model_post_init(self, __context: Any) -> None:  # ruff:ignore[any-type]
         """Validate calibration data after initialization.
 
         Raises:
@@ -704,7 +704,7 @@ class SystemConfig(BaseModel):
 # EXPORTS
 # ============================================================================
 
-__all__ = [  # noqa: RUF022  (grouped by domain, which reads better than sorted)
+__all__ = [  # ruff:ignore[unsorted-dunder-all]  (grouped by domain, which reads better than sorted)
     # Enums
     "TipState",
     "FluidDisplacement",

--- a/src/tricca_autopipette/core/plates.py
+++ b/src/tricca_autopipette/core/plates.py
@@ -359,7 +359,7 @@ class Plate(ABC):
 
     @property
     def current_index(self) -> int:
-        """Get the flat well index the cursor currently points at.
+        """The flat well index the cursor currently points at.
 
         Returns:
             Zero-based index into `wells`. Equals `curr` for a default
@@ -382,7 +382,7 @@ class Plate(ABC):
 
     @property
     def current_row(self) -> int:
-        """Get the current row index based on current well position.
+        """The current row index based on current well position.
 
         Returns:
             Zero-indexed row number of the current well.
@@ -403,7 +403,7 @@ class Plate(ABC):
 
     @property
     def current_col(self) -> int:
-        """Get the current column index based on current well position.
+        """The current column index based on current well position.
 
         Returns:
             Zero-indexed column number of the current well.
@@ -489,7 +489,7 @@ class Plate(ABC):
 
     @property
     def total_wells(self) -> int:
-        """Return the total number of wells.
+        """The total number of wells.
 
         Returns:
             Total count of wells in the plate.
@@ -666,11 +666,11 @@ class PlateArray(Plate):
             row: Zero-indexed row number.
             col: Zero-indexed column number.
 
-        Raises:
-            ValueError: If row and/or col is invalid
-
         Returns:
             Coordinate at the specified position, or None if out of bounds.
+
+        Raises:
+            ValueError: If row and/or col is invalid
         """
         if not self._is_valid_position(row, col):
             raise ValueError(f"row:{row} and col:{col} is invalid.")

--- a/src/tricca_autopipette/core/well.py
+++ b/src/tricca_autopipette/core/well.py
@@ -482,7 +482,7 @@ class Well:
 
     @property
     def strategy_type(self) -> StrategyType:
-        """Get the name of the current strategy.
+        """The name of the current strategy.
 
         Returns:
             StrategyType enum identifying the current dip strategy.

--- a/src/tricca_autopipette/daemon/control_server.py
+++ b/src/tricca_autopipette/daemon/control_server.py
@@ -210,7 +210,7 @@ class ControlServer:
                 "error": {"type": type(exc).__name__, "message": str(exc)},
             })
 
-    async def _call(self, method: str | None, params: dict[str, Any]) -> Any:  # noqa: ANN401
+    async def _call(self, method: str | None, params: dict[str, Any]) -> Any:  # ruff:ignore[any-type]
         """Route one method name to the corresponding service call.
 
         Args:

--- a/src/tricca_autopipette/daemon/moonraker_state.py
+++ b/src/tricca_autopipette/daemon/moonraker_state.py
@@ -43,7 +43,7 @@ DB_KEY_TIP_PRESENCE = "tip_presence"
 REQUIRED_HOMED_AXES = frozenset({"x", "y", "z"})
 
 
-def _as_dict(value: Any) -> dict[str, Any]:  # noqa: ANN401
+def _as_dict(value: Any) -> dict[str, Any]:  # ruff:ignore[any-type]
     """Narrow a loosely-typed JSON value to a dict, defaulting to empty.
 
     Args:
@@ -104,7 +104,7 @@ class MoonrakerStateTracker:
 
     @property
     def print_state(self) -> str:
-        """Return the last known Klipper ``print_stats.state`` value."""
+        """The last known Klipper ``print_stats.state`` value."""
         return self._print_state
 
     def on_print_state_change(self, callback: Callable[[str], None]) -> None:
@@ -118,7 +118,7 @@ class MoonrakerStateTracker:
         """
         self._print_state_callbacks.append(callback)
 
-    def _on_status_update(self, params: Any) -> None:  # noqa: ANN401
+    def _on_status_update(self, params: Any) -> None:  # ruff:ignore[any-type]
         """Handle a ``notify_status_update`` push from Moonraker.
 
         Args:

--- a/src/tricca_autopipette/daemon/service.py
+++ b/src/tricca_autopipette/daemon/service.py
@@ -178,8 +178,8 @@ def require_homed(
         @functools.wraps(func)
         def wrapper(
             self: AutoPipetteService,
-            *args: Any,  # noqa: ANN401
-            **kwargs: Any,  # noqa: ANN401
+            *args: Any,  # ruff:ignore[any-type]
+            **kwargs: Any,  # ruff:ignore[any-type]
         ) -> CommandResult:
             homed = self.moonraker_state is not None and self.moonraker_state.is_homed()
             if not homed:
@@ -221,7 +221,7 @@ def persist_tip_liquid_state(
     """
 
     @functools.wraps(func)
-    def wrapper(self: AutoPipetteService, *args: Any, **kwargs: Any) -> CommandResult:  # noqa: ANN401
+    def wrapper(self: AutoPipetteService, *args: Any, **kwargs: Any) -> CommandResult:  # ruff:ignore[any-type]
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -267,7 +267,7 @@ def persist_tip_presence(
     """
 
     @functools.wraps(func)
-    def wrapper(self: AutoPipetteService, *args: Any, **kwargs: Any) -> CommandResult:  # noqa: ANN401
+    def wrapper(self: AutoPipetteService, *args: Any, **kwargs: Any) -> CommandResult:  # ruff:ignore[any-type]
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -718,7 +718,15 @@ class AutoPipetteService:
                 all-zero-offset no-op case, unlike the pre-Phase-3 behavior --
                 see ``require_homed``'s docstring).
         """
-        if args.x == 0.0 and args.y == 0.0 and args.z == 0.0:
+        # Exact sentinel check, not an arithmetic result: args.x/y/z are the
+        # literal user-supplied offsets (default 0.0 when omitted), and an
+        # isclose() tolerance would silently swallow a genuinely tiny
+        # requested move as a no-op.
+        if (
+            args.x == 0.0  # ruff:ignore[float-equality-comparison]
+            and args.y == 0.0  # ruff:ignore[float-equality-comparison]
+            and args.z == 0.0  # ruff:ignore[float-equality-comparison]
+        ):
             return CommandResult(
                 ok=False, message="No movement — all offsets are zero."
             )
@@ -1850,7 +1858,7 @@ class AutoPipetteService:
             )
         return CommandResult(ok=True, message=f"Subscribed to '{method}'.")
 
-    def _forward_raw_notification(self, method: str, params: Any) -> None:  # noqa: ANN401
+    def _forward_raw_notification(self, method: str, params: Any) -> None:  # ruff:ignore[any-type]
         """Re-broadcast a subscribed raw Moonraker notification.
 
         Args:

--- a/src/tricca_autopipette/moonraker/moonraker_requests.py
+++ b/src/tricca_autopipette/moonraker/moonraker_requests.py
@@ -931,7 +931,7 @@ class MoonrakerRequests:
         self,
         namespace: str,
         key: str,
-        value: Any,  # noqa: ANN401
+        value: Any,  # ruff:ignore[any-type]
     ) -> dict[str, Any]:
         """Set database item.
 

--- a/tests/core/test_json_config_manager.py
+++ b/tests/core/test_json_config_manager.py
@@ -73,7 +73,8 @@ class TestExtends:
         config = JsonConfigManager().load_system_config(child)
 
         assert config.system_name == "Protocol"  # child wins
-        assert config.gantry.speed_xy == 1234.0  # inherited
+        # inherited; exact JSON round-trip of a literal, not a computed value
+        assert config.gantry.speed_xy == 1234.0  # ruff:ignore[float-equality-comparison]
         assert config.network["hostname"] == "bench.local"  # inherited
 
     def test_child_overrides_parent(self, write_system_config: Any) -> None:
@@ -87,7 +88,8 @@ class TestExtends:
 
         config = JsonConfigManager().load_system_config(child)
 
-        assert config.gantry.speed_xy == 9999.0
+        # Exact JSON round-trip of a literal, not a computed value.
+        assert config.gantry.speed_xy == 9999.0  # ruff:ignore[float-equality-comparison]
 
     def test_multi_level_chain(self, write_system_config: Any) -> None:
         write_system_config("a.json", {"system_name": "A", "pipette": "p100_vertical"})
@@ -99,7 +101,8 @@ class TestExtends:
         config = JsonConfigManager().load_system_config(child)
 
         assert config.system_name == "A"
-        assert config.gantry.speed_z == 42.0
+        # Exact JSON round-trip of a literal, not a computed value.
+        assert config.gantry.speed_z == 42.0  # ruff:ignore[float-equality-comparison]
 
     def test_nearest_ancestor_wins(self, write_system_config: Any) -> None:
         """A grandparent must not override the parent."""


### PR DESCRIPTION
## Context

`main` currently fails `ruff check` (38 errors) and `pyright` (1 error) — tracked in #18 ("Green the tree"), which blocks #19 (CI gating). Verified locally since this repo has no CI configured yet (`gh pr checks` reports nothing).

## What changed

**31 mechanical ruff fixes**, applied via `ruff check --fix`:
- `noqa` comments converted to the `ruff:ignore[]` syntax ruff now prefers.
- Rule codes renamed to rule names in `pyproject.toml`'s `ignore`/`per-file-ignores`.
- 7 property docstrings reworded off a leading verb ("Get X" → "The X").
- One `Returns`/`Raises` section reordered.

**7 ruff fixes needing individual judgment** (per #18's own warning not to blanket-`--fix` these):
- **Real bug**: the kiosk's FastAPI `lifespan` didn't wrap `yield` in `try/finally` — an exception raised anywhere during the app's runtime would skip the cleanup code after `yield`, leaking the `WebSocketClient` background thread instead of stopping it. Fixed with `try/finally`.
- **6 suppressed as legitimate**: `move_rel`'s all-zero-offset check (`args.x == 0.0 and ...`) and 3 test assertions comparing JSON-round-tripped config literals (`config.gantry.speed_xy == 1234.0`, etc.) are genuine exact-value/sentinel comparisons, not arithmetic results. An `isclose()` tolerance would be a real behavior change here — it would silently treat a tiny requested offset as a no-op, or mask a real regression in config round-tripping. Suppressed with `ruff:ignore[float-equality-comparison]` plus a comment explaining why, rather than papering over with a tolerance.

**pyright fix**: `gcode_manager.py`'s `batch_mode` was a `@contextmanager` annotated `-> Iterator[GCodeManager]`, which pyright flags as deprecated in favor of `-> Generator[GCodeManager]`. Trivial swap, no behavior change.

## Testing

- `ruff check .` — clean (was 38 errors)
- `ruff format --check .` — clean (unchanged, 82 files)
- `pyright` — clean (was 1 error)
- `pytest` — 548 passed (unchanged)

This closes out #18 — both tools are at zero, so #19 (CI workflow + branch protection) can gate on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)