### PR TITLE
Add real-control-plane tests for the kiosk backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ license-files = ["LICENSE"]
 # Development tools.
 dev = [
     "coverage",
+    "httpx2",  # starlette.testclient.TestClient's transport, for kiosk tests
     "pyright",
     "pytest",
     "ruff",
@@ -232,10 +233,9 @@ addopts = "-ra"
 
 branch = true
 
-# TODO:
-# Replace with your package name.
 source = [
     "tricca_autopipette",
+    "autopipette_kiosk",
 ]
 
 [project.scripts]

--- a/tests/kiosk/conftest.py
+++ b/tests/kiosk/conftest.py
@@ -1,0 +1,61 @@
+"""Shared fixtures for kiosk (`autopipette_kiosk`) control-plane tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import WebSocket
+from fastapi.testclient import TestClient
+from support.live_control_plane import LiveControlPlane
+
+from autopipette_kiosk import main as kiosk_main
+from tricca_autopipette.core.pipette_constants import DefaultPaths
+
+
+@pytest.fixture
+def protocols_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect both the kiosk's and the daemon's protocol directories.
+
+    `autopipette_kiosk.main.PROTOCOLS_DIR` (the kiosk's own existence
+    pre-check/listing) and `DefaultPaths.DIR_PROTOCOL` (what
+    `AutoPipetteService.start_run`, reached over the real control plane,
+    actually reads) normally point at the same physical `protocols/` folder
+    in a single-machine deployment. Both are resolved once, not read fresh
+    per request (see CLAUDE.md), so patching each module constant directly
+    -- not the env vars they were originally read from -- is the only way
+    to redirect them per test.
+    """
+    monkeypatch.setattr(kiosk_main, "PROTOCOLS_DIR", tmp_path)
+    monkeypatch.setattr(DefaultPaths, "DIR_PROTOCOL", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def kiosk_client(
+    live_control_plane: LiveControlPlane, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    """A `TestClient` for the kiosk app, connected to a real control plane.
+
+    Used as `with TestClient(app) as client:` internally -- required for
+    the app's `lifespan` (and thus its own control-plane `WebSocketClient`)
+    to actually run; a `TestClient` used without a `with` block dispatches
+    HTTP routes without ever starting it (see `test_main.py`'s "not
+    connected" tests, which rely on exactly that to get a clean
+    `_control_client is None` state for free).
+
+    Also resets the run/breakpoint/websocket-client module globals
+    `autopipette_kiosk/main.py` keeps instead of per-request state (it's a
+    long-lived singleton in production) -- tests share that same module
+    across the whole session, so leftover state from one test would
+    otherwise leak into the next.
+    """
+    empty_clients: set[WebSocket] = set()
+    monkeypatch.setattr(kiosk_main, "TAPD_CONTROL_URI", live_control_plane.url)
+    monkeypatch.setattr(kiosk_main, "_current_run", kiosk_main.RunStatus(status="idle"))
+    monkeypatch.setattr(kiosk_main, "_current_breakpoint", None)
+    monkeypatch.setattr(kiosk_main, "_ws_clients", empty_clients)
+
+    with TestClient(kiosk_main.app) as client:
+        yield client

--- a/tests/kiosk/test_main.py
+++ b/tests/kiosk/test_main.py
@@ -1,0 +1,273 @@
+"""Tests for the kiosk backend (`autopipette_kiosk/main.py`) against a real,
+
+in-process control plane.
+
+Issue #37 called this out as non-trivial logic, not pure forwarding: the
+`/ws/status` re-broadcast and the daemon-error-to-HTTP-status mapping in
+`/run`/`/home` are real client-side reactions to what a real `ControlServer`
+sends back, not something a test mocking `send_jsonrpc` directly can
+exercise honestly. Every test here drives the real FastAPI app (via
+`fastapi.testclient.TestClient`) against a real `ControlServer`
+(`tests/support/live_control_plane.py`, the same one `tests/cli/` uses for
+`RemoteTapShell`) over a real localhost socket.
+
+`autopipette_kiosk/main.py` keeps its run/breakpoint/websocket-client state
+in plain module globals rather than per-request state (it's a long-lived
+singleton in production) -- the `kiosk_client`/`protocols_dir` fixtures
+(`tests/kiosk/conftest.py`) reset and redirect those per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from support.live_control_plane import LiveControlPlane
+from support.polling import poll_until
+
+from autopipette_kiosk import main as kiosk_main
+from tricca_autopipette.core.pipette_constants import DefaultPaths
+
+
+class TestProtocolListing:
+    def test_empty_dir_returns_empty_list(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        del protocols_dir  # exists (redirected), just empty
+        response = kiosk_client.get("/protocols")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_lists_pipette_files_sorted_by_name(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "b.pipette").write_text("wait 1\n")
+        (protocols_dir / "a.pipette").write_text("wait 1\n")
+        (protocols_dir / "not-a-protocol.txt").write_text("ignore me\n")
+
+        response = kiosk_client.get("/protocols")
+
+        assert response.json() == [
+            {"name": "a", "filename": "a.pipette"},
+            {"name": "b", "filename": "b.pipette"},
+        ]
+
+    def test_missing_dir_returns_500(
+        self,
+        kiosk_client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(kiosk_main, "PROTOCOLS_DIR", tmp_path / "does-not-exist")
+
+        response = kiosk_client.get("/protocols")
+
+        assert response.status_code == 500
+
+
+class TestRunEndpoint:
+    def test_starts_a_run_and_returns_the_real_daemon_reply(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+
+        response = kiosk_client.post("/run", json={"filename": "a.pipette"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "running"
+        assert "a.pipette" in body["message"]
+
+    def test_missing_file_in_the_kiosk_dir_returns_404_without_contacting_daemon(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        del protocols_dir
+        response = kiosk_client.post(
+            "/run", json={"filename": "does-not-exist.pipette"}
+        )
+
+        assert response.status_code == 404
+
+    def test_file_missing_only_on_the_daemon_side_returns_a_real_404(
+        self,
+        kiosk_client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Deliberately mismatched dirs: the kiosk's own PROTOCOLS_DIR has the
+        # file (passes its local pre-check) but the daemon's DIR_PROTOCOL --
+        # a genuinely separate system, reached over the real control plane
+        # -- does not. Only a real round trip can surface this; a test that
+        # mocked send_jsonrpc would have no daemon-side file list to be
+        # wrong about.
+        kiosk_dir = tmp_path / "kiosk-protocols"
+        kiosk_dir.mkdir()
+        (kiosk_dir / "a.pipette").write_text('gcode_print "hi"\n')
+        daemon_dir = tmp_path / "daemon-protocols"
+        daemon_dir.mkdir()
+        monkeypatch.setattr(kiosk_main, "PROTOCOLS_DIR", kiosk_dir)
+        monkeypatch.setattr(DefaultPaths, "DIR_PROTOCOL", daemon_dir)
+
+        response = kiosk_client.post("/run", json={"filename": "a.pipette"})
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_second_run_while_one_is_active_returns_409(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+        first = kiosk_client.post("/run", json={"filename": "a.pipette"})
+        assert first.status_code == 200
+
+        second = kiosk_client.post("/run", json={"filename": "a.pipette"})
+
+        assert second.status_code == 409
+
+    def test_returns_503_when_the_daemon_is_not_connected(
+        self, protocols_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+        monkeypatch.setattr(kiosk_main, "_control_client", None)
+
+        # Not entered as `with TestClient(...) as client:` -- lifespan never
+        # runs, so `_control_client` stays None regardless of the monkeypatch
+        # above (belt-and-suspenders: makes the precondition explicit rather
+        # than relying on "lifespan never ran" alone).
+        client = TestClient(kiosk_main.app)
+        response = client.post("/run", json={"filename": "a.pipette"})
+
+        assert response.status_code == 503
+
+
+class TestHomeEndpoint:
+    def test_dispatches_init_and_reports_done(self, kiosk_client: TestClient) -> None:
+        response = kiosk_client.post("/home")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "done"
+
+    def test_returns_503_when_the_daemon_is_not_connected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(kiosk_main, "_control_client", None)
+
+        client = TestClient(kiosk_main.app)  # no lifespan, see TestRunEndpoint above
+        response = client.post("/home")
+
+        assert response.status_code == 503
+
+
+class TestIndexRoute:
+    def test_serves_the_frontend(self, kiosk_client: TestClient) -> None:
+        response = kiosk_client.get("/")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+
+class TestBreakpointRespond:
+    def test_returns_503_when_the_daemon_is_not_connected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(kiosk_main, "_control_client", None)
+
+        client = TestClient(kiosk_main.app)  # no lifespan, see TestRunEndpoint above
+        response = client.post("/breakpoint/respond", json={"proceed": True})
+
+        assert response.status_code == 503
+
+    def test_confirms_and_releases_a_pending_breakpoint(
+        self,
+        kiosk_client: TestClient,
+        protocols_dir: Path,
+        live_control_plane: LiveControlPlane,
+    ) -> None:
+        (protocols_dir / "bp.pipette").write_text(
+            'gcode_print "before"\nbreak\ngcode_print "after"\n'
+        )
+
+        with kiosk_client.websocket_connect("/ws/status") as ws:
+            assert ws.receive_json()["status"] == "idle"
+
+            kiosk_client.post("/run", json={"filename": "bp.pipette"})
+            assert ws.receive_json()["status"] == "running"
+
+            pending = ws.receive_json()
+            assert pending["breakpoint"] is not None
+            assert pending["breakpoint"]["pending"] is True
+
+            response = kiosk_client.post("/breakpoint/respond", json={"proceed": True})
+            assert response.status_code == 200
+            assert response.json() == {"ok": True}
+
+            cleared = ws.receive_json()
+            assert cleared["breakpoint"] is None
+
+        # request_breakpoint() blocks the worker thread for the run's whole
+        # duration, holding service._lock the entire time -- proceeding past
+        # the breakpoint is what releases it (the same real signal
+        # tests/cli/test_remote_shell.py checks for RemoteTapShell's
+        # "continue", since there's no real Moonraker connection here to
+        # ever move status off "running" on its own).
+        assert poll_until(lambda: not live_control_plane.service._lock.locked())
+
+
+class TestStatusEndpoint:
+    def test_idle_by_default(self, kiosk_client: TestClient) -> None:
+        response = kiosk_client.get("/status")
+
+        assert response.json() == {"status": "idle", "message": ""}
+
+    def test_reflects_the_real_status_after_a_run_starts(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+
+        kiosk_client.post("/run", json={"filename": "a.pipette"})
+        response = kiosk_client.get("/status")
+
+        assert response.json()["status"] == "running"
+
+
+class TestWebSocketStatusBroadcast:
+    def test_new_connection_receives_the_current_status_immediately(
+        self, kiosk_client: TestClient
+    ) -> None:
+        with kiosk_client.websocket_connect("/ws/status") as ws:
+            payload = ws.receive_json()
+
+        assert payload == {"status": "idle", "message": "", "breakpoint": None}
+
+    def test_receives_a_push_when_a_run_starts(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+
+        with kiosk_client.websocket_connect("/ws/status") as ws:
+            assert ws.receive_json()["status"] == "idle"
+
+            kiosk_client.post("/run", json={"filename": "a.pipette"})
+
+            pushed = ws.receive_json()
+            assert pushed["status"] == "running"
+            assert pushed["breakpoint"] is None
+
+    def test_fans_out_to_every_connected_client(
+        self, kiosk_client: TestClient, protocols_dir: Path
+    ) -> None:
+        (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+
+        with (
+            kiosk_client.websocket_connect("/ws/status") as ws1,
+            kiosk_client.websocket_connect("/ws/status") as ws2,
+        ):
+            ws1.receive_json()
+            ws2.receive_json()
+
+            kiosk_client.post("/run", json={"filename": "a.pipette"})
+
+            assert ws1.receive_json()["status"] == "running"
+            assert ws2.receive_json()["status"] == "running"


### PR DESCRIPTION
## Summary
PR 3 of the 6-PR test-suite audit rooted at #34 (see the #34 comment recording
the full breakdown), and the kiosk half of #37. Closes #37 (both halves now
covered).

**Stacked on #45** (the CLI half) — this PR's base branch is
`test/remote-shell-control-plane`, not `main`, since it reuses the
`tests/support/live_control_plane.py` infra built there rather than
duplicating it. The diff shown here is kiosk-only; merge #45 first (or into
this branch) and the diff against `main` will resolve to just this PR's
changes.

`autopipette_kiosk/main.py` had zero test coverage and wasn't even in
`[tool.coverage.run]`'s `source` list. Issue #37 called out its `/ws/status`
re-broadcast and completion-detection logic as real, non-trivial behavior —
not pure forwarding — worth testing honestly rather than mocking at the
`send_jsonrpc` boundary.

## Approach
Same as #45: a real `ControlServer` (via `LiveControlPlane`) over a real
localhost socket, this time driven through `fastapi.testclient.TestClient`
against the real FastAPI app.

**New dev dependency: `httpx2`.** `starlette.testclient.TestClient`'s
transport in this environment is `httpx2`, not the classic `httpx` — that
package name isn't installable here; `httpx2` is its successor and is what's
actually importable/required by the installed `starlette`.

Two things specific to this module needed handling in
`tests/kiosk/conftest.py`:
- `autopipette_kiosk/main.py` keeps run/breakpoint/websocket-client state in
  plain module globals (a long-lived singleton in production), not
  per-request state. The `kiosk_client` fixture resets those between tests
  via `monkeypatch` so state can't leak across the one shared `app` object
  every test in the session imports.
- `PROTOCOLS_DIR` (kiosk-side) and `DefaultPaths.DIR_PROTOCOL` (daemon-side,
  reached over the real control plane) are both resolved once at import
  time. `protocols_dir` patches both module constants to the same temp dir,
  matching how they coincide in a real single-machine deployment.

## Coverage
`tests/kiosk/test_main.py`, 18 tests:
- **`/ws/status`'s re-broadcast** (issue #37's specific ask): a fresh
  connection's initial payload, a push when a run starts, a push carrying
  real breakpoint details, and fan-out to multiple connected browsers — all
  driven by real `notify_run_status`/`notify_breakpoint` pushes arriving
  over the wire
- **Real error-to-HTTP-status mapping** in `/run` (404/409/503) against
  genuine `RunAlreadyActiveError`/`FileNotFoundError` responses, including
  one test with deliberately mismatched kiosk-side vs. daemon-side protocol
  directories — only a real round trip surfaces that class of bug
- **`/breakpoint/respond`** actually releasing the daemon's blocked worker
  thread (verified via the real `service._lock`, the same technique #45
  uses for `RemoteTapShell`'s "continue")
- `/protocols`, `/home`, `/status`, `/` — representative coverage of the
  rest

Also flips `[tool.coverage.run]`'s `source` to include `autopipette_kiosk`,
which had been invisible to coverage reporting entirely.

`autopipette_kiosk/main.py` coverage: untracked → 88%. Remaining gaps are
defensive/exception branches (a connection dropping mid-broadcast, malformed
notification payloads) that are harder to engineer deterministically than
what's covered here.

## Testing
- `pytest` (full suite, this branch) — 589 passed (548 baseline + 23 from
  #45 + 18 new), 3 repeated runs, no flakiness
- `pytest -W error::ResourceWarning` — clean
- `ruff check` / `ruff format --check` / `pyright` — clean repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)