### PR TITLE
Add coverage for daemon/moonraker_state.py and daemon/main.py

### DIFF
--- a/tests/daemon/test_main.py
+++ b/tests/daemon/test_main.py
@@ -1,0 +1,385 @@
+"""Unit tests for the ``tapd`` entry point, ``daemon/main.py``.
+
+Covers argument parsing, config-path resolution/validation wiring, and
+``main()``'s exit-code handling for each caught exception type. ``_serve``
+builds a real ``AutoPipetteService``/``ControlServer`` pair, so its tests
+monkeypatch both classes with tiny in-process fakes rather than doing real
+Moonraker/network I/O -- consistent with how the rest of this module's
+callers (``AutoPipetteService`` gap-fill in ``test_service_*.py``) fake only
+at the Moonraker boundary, here pushed one layer further out.
+
+``_serve`` blocks on a ``asyncio.Event`` set by a SIGINT/SIGTERM handler it
+registers on the running loop -- the same shutdown path a real ``tapd``
+process uses. Tests exercise that real path (rather than reaching into
+``_serve``'s internals) by having the fake ``ControlServer.start()`` schedule
+a self-``SIGTERM`` shortly after "starting", simulating an operator
+Ctrl-C. The signal handler is registered before ``start()`` runs, so there is
+no race with the default disposition.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import logging
+import os
+import signal
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from tricca_autopipette.core.pipette_constants import DefaultFilenames, DefaultPaths
+from tricca_autopipette.daemon import main as main_module
+from tricca_autopipette.daemon.control_server import DEFAULT_HOST, DEFAULT_PORT
+
+
+def _base_args(**overrides: Any) -> argparse.Namespace:
+    defaults: dict[str, Any] = {
+        "config": None,
+        "config_gantry": None,
+        "config_pipette": None,
+        "config_liquids": None,
+        "config_locations": None,
+        "log_file": "tapd.log",
+        "log_level": "INFO",
+        "no_connect": True,
+        "local_connect": False,
+        "host": DEFAULT_HOST,
+        "port": DEFAULT_PORT,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestParseArguments:
+    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["tapd"])
+
+        args = main_module.parse_arguments()
+
+        assert args.config is None
+        assert args.config_gantry is None
+        assert args.config_pipette is None
+        assert args.config_locations is None
+        assert args.config_liquids is None
+        assert args.log_file == main_module.DEFAULT_LOG_FILE
+        assert args.log_level == "INFO"
+        assert args.no_connect is False
+        assert args.local_connect is False
+        assert args.host == DEFAULT_HOST
+        assert args.port == DEFAULT_PORT
+
+    def test_config_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "tapd",
+                "--config",
+                "sys.json",
+                "--config-gantry",
+                "gantry.json",
+                "--config-pipette",
+                "pipette.json",
+                "--config-locations",
+                "locations.json",
+                "--config-liquids",
+                "liquids.json",
+            ],
+        )
+
+        args = main_module.parse_arguments()
+
+        assert args.config == "sys.json"
+        assert args.config_gantry == "gantry.json"
+        assert args.config_pipette == "pipette.json"
+        assert args.config_locations == "locations.json"
+        assert args.config_liquids == "liquids.json"
+
+    def test_no_connect_and_local_connect_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["tapd", "--no-connect", "--local-connect"])
+
+        args = main_module.parse_arguments()
+
+        assert args.no_connect is True
+        assert args.local_connect is True
+
+    def test_host_port_and_log_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "tapd",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9999",
+                "--log-level",
+                "DEBUG",
+                "--log-file",
+                "custom.log",
+            ],
+        )
+
+        args = main_module.parse_arguments()
+
+        assert args.host == "0.0.0.0"
+        assert args.port == 9999
+        assert args.log_level == "DEBUG"
+        assert args.log_file == "custom.log"
+
+    def test_rejects_an_invalid_log_level(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["tapd", "--log-level", "NOPE"])
+
+        with pytest.raises(SystemExit):
+            main_module.parse_arguments()
+
+
+class TestSetupLogging:
+    def test_configures_a_file_and_stream_handler_at_the_given_level(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def _fake_basic_config(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(logging, "basicConfig", _fake_basic_config)
+        sentinel_stdout = io.StringIO()
+        monkeypatch.setattr(main_module.sys, "stdout", sentinel_stdout)
+        log_file = tmp_path / "tapd.log"
+
+        main_module.setup_logging(str(log_file), logging.DEBUG)
+
+        assert captured["level"] == logging.DEBUG
+        handlers = cast("list[logging.Handler]", captured["handlers"])
+        assert len(handlers) == 2
+        file_handler, stream_handler = handlers
+        assert isinstance(file_handler, logging.FileHandler)
+        assert file_handler.baseFilename == str(log_file)
+        assert (
+            cast("logging.StreamHandler[Any]", stream_handler).stream is sentinel_stdout
+        )
+
+
+class TestServe:
+    def _drive(
+        self, monkeypatch: pytest.MonkeyPatch, args: argparse.Namespace
+    ) -> dict[str, Any]:
+        """Run ``_serve(args)`` to completion against fakes, self-terminating.
+
+        Returns:
+            A dict with the constructed fake ``"service"`` and ``"server"``
+            instances, once ``_serve`` has returned.
+        """
+        created: dict[str, Any] = {}
+
+        class _FakeControlServer:
+            def __init__(self, service: Any, host: str, port: int) -> None:
+                self.service = service
+                self.host = host
+                self.port = port
+                self.started = False
+                self.stopped = False
+                created["server"] = self
+
+            async def start(self) -> None:
+                self.started = True
+                # Simulate an operator hitting Ctrl-C shortly after the
+                # daemon comes up -- scheduled on the same running loop, so
+                # there's no cross-thread race with the signal handlers
+                # `_serve` registers before calling `start()`.
+                asyncio.get_running_loop().call_later(
+                    0.02, os.kill, os.getpid(), signal.SIGTERM
+                )
+
+            async def stop(self) -> None:
+                self.stopped = True
+
+        class _FakeAutoPipetteService:
+            def __init__(self, **kwargs: Any) -> None:
+                self.kwargs = kwargs
+                created["service"] = self
+
+        monkeypatch.setattr(main_module, "ControlServer", _FakeControlServer)
+        monkeypatch.setattr(main_module, "AutoPipetteService", _FakeAutoPipetteService)
+
+        asyncio.run(main_module._serve(args))
+        return created
+
+    def test_starts_and_cleanly_stops_the_control_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args())
+
+        assert created["server"].started is True
+        assert created["server"].stopped is True
+
+    def test_binds_the_requested_host_and_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args(host="0.0.0.0", port=1234))
+
+        assert created["server"].host == "0.0.0.0"
+        assert created["server"].port == 1234
+
+    def test_default_config_paths_resolve_to_default_filenames(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args())
+
+        kwargs = created["service"].kwargs
+        assert kwargs["config_system"] == (
+            DefaultPaths.DIR_CONFIG_SYSTEM / DefaultFilenames.CONFIG_SYSTEM
+        )
+        assert kwargs["config_gantry"] is None
+        assert kwargs["config_pipette"] is None
+        assert kwargs["config_locations"] is None
+        assert kwargs["config_liquids"] is None
+
+    def test_explicit_config_paths_resolve_under_their_config_dirs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(
+            monkeypatch,
+            _base_args(
+                config="sys.json",
+                config_gantry="gantry.json",
+                config_pipette="pipette.json",
+                config_locations="locations.json",
+                config_liquids="liquids.json",
+            ),
+        )
+
+        kwargs = created["service"].kwargs
+        assert kwargs["config_system"] == DefaultPaths.DIR_CONFIG_SYSTEM / "sys.json"
+        assert kwargs["config_gantry"] == DefaultPaths.DIR_CONFIG_GANTRY / "gantry.json"
+        assert (
+            kwargs["config_pipette"] == DefaultPaths.DIR_CONFIG_PIPETTE / "pipette.json"
+        )
+        assert (
+            kwargs["config_locations"]
+            == DefaultPaths.DIR_CONFIG_LOCATIONS / "locations.json"
+        )
+        assert (
+            kwargs["config_liquids"] == DefaultPaths.DIR_CONFIG_LIQUIDS / "liquids.json"
+        )
+
+    def test_no_connect_flag_disables_the_websocket_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args(no_connect=True))
+
+        assert created["service"].kwargs["connect_websocket"] is False
+
+    def test_omitting_no_connect_enables_the_websocket_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args(no_connect=False))
+
+        assert created["service"].kwargs["connect_websocket"] is True
+
+    def test_local_connect_flag_is_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        created = self._drive(monkeypatch, _base_args(local_connect=True))
+
+        assert created["service"].kwargs["connect_local_websocket"] is True
+
+
+class TestMain:
+    def _patch_common(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        args: argparse.Namespace,
+        *,
+        validate_error: Exception | None = None,
+        serve_error: BaseException | None = None,
+    ) -> dict[str, Any]:
+        calls: dict[str, Any] = {}
+
+        monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+
+        def _fake_setup_logging(log_file: str, level: int) -> None:
+            calls["setup_logging"] = (log_file, level)
+
+        monkeypatch.setattr(main_module, "setup_logging", _fake_setup_logging)
+
+        def _fake_validate(**kwargs: Any) -> None:
+            calls["validate_config_files"] = kwargs
+            if validate_error is not None:
+                raise validate_error
+
+        monkeypatch.setattr(main_module, "validate_config_files", _fake_validate)
+
+        def _fake_asyncio_run(coro: Any) -> None:
+            coro.close()  # avoid an "never awaited" warning
+            calls["asyncio_run_called"] = True
+            if serve_error is not None:
+                raise serve_error
+
+        monkeypatch.setattr(main_module.asyncio, "run", _fake_asyncio_run)
+        return calls
+
+    def test_success_path_returns_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        args = _base_args()
+        calls = self._patch_common(monkeypatch, args)
+
+        result = main_module.main()
+
+        assert result == 0
+        assert calls["asyncio_run_called"] is True
+        assert calls["setup_logging"] == (args.log_file, logging.INFO)
+        assert calls["validate_config_files"] == {
+            "config_system": args.config,
+            "config_gantry": args.config_gantry,
+            "config_pipette": args.config_pipette,
+            "config_locations": args.config_locations,
+            "config_liquids": args.config_liquids,
+        }
+
+    def test_file_not_found_error_returns_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        args = _base_args()
+        self._patch_common(
+            monkeypatch, args, validate_error=FileNotFoundError("missing.json")
+        )
+
+        assert main_module.main() == 1
+
+    def test_value_error_returns_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        args = _base_args()
+        self._patch_common(monkeypatch, args, validate_error=ValueError("bad file"))
+
+        assert main_module.main() == 1
+
+    def test_keyboard_interrupt_returns_130(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        args = _base_args()
+        self._patch_common(monkeypatch, args, serve_error=KeyboardInterrupt())
+
+        assert main_module.main() == 130
+
+    def test_unexpected_exception_returns_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        args = _base_args()
+        self._patch_common(monkeypatch, args, serve_error=RuntimeError("boom"))
+
+        assert main_module.main() == 1
+
+    def test_log_level_string_is_uppercased_before_lookup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        args = _base_args(log_level="debug")
+        calls = self._patch_common(monkeypatch, args)
+
+        assert main_module.main() == 0
+
+        assert calls["setup_logging"] == (args.log_file, logging.DEBUG)

--- a/tests/daemon/test_moonraker_state.py
+++ b/tests/daemon/test_moonraker_state.py
@@ -1,0 +1,352 @@
+"""Unit tests for ``daemon/moonraker_state.py``'s ``MoonrakerStateTracker``.
+
+Uses `FakeWebSocketClient` (the same fake `AutoPipetteService`-layer tests
+build against) plus a real `MoonrakerRequests`, since the tracker's whole
+job is translating between the two -- there is no Moonraker-boundary fake
+specific to this module to build, just canned `send_jsonrpc` responses.
+"""
+
+from __future__ import annotations
+
+from fakes.fake_websocket_client import FakeWebSocketClient
+
+from tricca_autopipette.daemon.moonraker_state import (
+    DB_KEY_CURRENT_LIQUID,
+    DB_KEY_HAS_LIQUID,
+    DB_KEY_TIP_PRESENCE,
+    DB_KEY_TIP_STATE,
+    DB_NAMESPACE,
+    MoonrakerStateTracker,
+)
+from tricca_autopipette.moonraker.moonraker_requests import MoonrakerRequests
+
+
+def _tracker(client: FakeWebSocketClient) -> MoonrakerStateTracker:
+    return MoonrakerStateTracker(client, MoonrakerRequests())  # type: ignore[arg-type]
+
+
+class TestStart:
+    def test_registers_status_update_handler(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.start()
+
+        assert "notify_status_update" in fake_websocket_client.handlers
+
+    def test_subscribes_to_toolhead_and_print_stats(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.start()
+
+        assert len(fake_websocket_client.sent_requests) == 1
+        request = fake_websocket_client.sent_requests[0]
+        assert request["method"] == "printer.objects.subscribe"
+        assert set(request["params"]["objects"]) == {"toolhead", "print_stats"}
+
+    def test_applies_initial_status_from_subscribe_response(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({
+            "result": {
+                "status": {
+                    "toolhead": {"homed_axes": "xyz"},
+                    "print_stats": {"state": "printing"},
+                }
+            }
+        })
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.start()
+
+        assert tracker.is_homed() is True
+        assert tracker.print_state == "printing"
+
+    def test_tolerates_a_response_with_no_result(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({})
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.start()  # must not raise
+
+        assert tracker.is_homed() is False
+        assert tracker.print_state == "standby"
+
+
+class TestIsHomed:
+    def test_false_before_any_status_is_applied(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        assert tracker.is_homed() is False
+
+    def test_true_once_x_y_z_all_reported_homed(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker._apply_status({"toolhead": {"homed_axes": ["x", "y", "z"]}})
+
+        assert tracker.is_homed() is True
+
+    def test_false_when_an_axis_is_missing(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker._apply_status({"toolhead": {"homed_axes": "xy"}})
+
+        assert tracker.is_homed() is False
+
+    def test_extra_axes_beyond_xyz_still_count_as_homed(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker._apply_status({"toolhead": {"homed_axes": "xyze"}})
+
+        assert tracker.is_homed() is True
+
+    def test_a_later_status_can_clear_homed_state(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker._apply_status({"toolhead": {"homed_axes": "xyz"}})
+        assert tracker.is_homed() is True
+
+        tracker._apply_status({"toolhead": {"homed_axes": ""}})
+
+        assert tracker.is_homed() is False
+
+
+class TestStatusUpdateNotifications:
+    def test_notification_updates_homed_axes(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker.start()
+
+        fake_websocket_client.trigger_notification(
+            "notify_status_update",
+            [{"toolhead": {"homed_axes": "xyz"}}, 123.0],
+        )
+
+        assert tracker.is_homed() is True
+
+    def test_notification_params_as_bare_dict_also_works(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker.start()
+
+        fake_websocket_client.trigger_notification(
+            "notify_status_update", {"toolhead": {"homed_axes": "xyz"}}
+        )
+
+        assert tracker.is_homed() is True
+
+    def test_empty_params_are_ignored(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker.start()
+
+        fake_websocket_client.trigger_notification("notify_status_update", [])
+        fake_websocket_client.trigger_notification("notify_status_update", None)
+
+        assert tracker.is_homed() is False
+        assert tracker.print_state == "standby"
+
+    def test_non_dict_candidate_is_ignored(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker.start()
+
+        fake_websocket_client.trigger_notification("notify_status_update", [None])
+
+        assert tracker.is_homed() is False
+
+
+class TestPrintStateCallbacks:
+    def test_callback_invoked_on_state_change(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        seen: list[str] = []
+        tracker.on_print_state_change(seen.append)
+
+        tracker._apply_status({"print_stats": {"state": "printing"}})
+
+        assert seen == ["printing"]
+        assert tracker.print_state == "printing"
+
+    def test_callback_not_invoked_when_state_is_unchanged(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        tracker._apply_status({"print_stats": {"state": "printing"}})
+        seen: list[str] = []
+        tracker.on_print_state_change(seen.append)
+
+        tracker._apply_status({"print_stats": {"state": "printing"}})
+
+        assert seen == []
+
+    def test_multiple_callbacks_all_invoked_in_registration_order(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+        seen: list[str] = []
+        tracker.on_print_state_change(lambda state: seen.append(f"a:{state}"))
+        tracker.on_print_state_change(lambda state: seen.append(f"b:{state}"))
+
+        tracker._apply_status({"print_stats": {"state": "complete"}})
+
+        assert seen == ["a:complete", "b:complete"]
+
+
+class TestLoadTipLiquidState:
+    def test_returns_all_three_keys_when_all_are_stored(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({"result": {"value": "attached"}})
+        fake_websocket_client.queue_response({"result": {"value": True}})
+        fake_websocket_client.queue_response({"result": {"value": "water"}})
+        tracker = _tracker(fake_websocket_client)
+
+        result = tracker.load_tip_liquid_state()
+
+        assert result == {
+            DB_KEY_TIP_STATE: "attached",
+            DB_KEY_HAS_LIQUID: True,
+            DB_KEY_CURRENT_LIQUID: "water",
+        }
+        methods = [r["method"] for r in fake_websocket_client.sent_requests]
+        assert methods == ["server.database.get_item"] * 3
+        keys = [r["params"]["key"] for r in fake_websocket_client.sent_requests]
+        assert keys == [DB_KEY_TIP_STATE, DB_KEY_HAS_LIQUID, DB_KEY_CURRENT_LIQUID]
+        assert all(
+            r["params"]["namespace"] == DB_NAMESPACE
+            for r in fake_websocket_client.sent_requests
+        )
+
+    def test_omits_keys_with_no_stored_value(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        # First run: none of the three keys have ever been persisted, so
+        # Moonraker's `get_item` response lacks the shape `load_tip_liquid_state`
+        # expects, and each lookup falls into the `except` branch.
+        fake_websocket_client.queue_response({})
+        fake_websocket_client.queue_response({})
+        fake_websocket_client.queue_response({})
+        tracker = _tracker(fake_websocket_client)
+
+        result = tracker.load_tip_liquid_state()
+
+        assert result == {}
+
+    def test_partial_state_when_only_some_keys_are_stored(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({"result": {"value": "attached"}})
+        fake_websocket_client.queue_response({})  # has_liquid never stored
+        fake_websocket_client.queue_response({"result": {"value": "water"}})
+        tracker = _tracker(fake_websocket_client)
+
+        result = tracker.load_tip_liquid_state()
+
+        assert result == {
+            DB_KEY_TIP_STATE: "attached",
+            DB_KEY_CURRENT_LIQUID: "water",
+        }
+
+
+class TestSaveTipLiquidState:
+    def test_sends_one_post_item_per_key_in_order(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.save_tip_liquid_state("attached", True, "water")
+
+        requests = fake_websocket_client.sent_requests
+        assert [r["method"] for r in requests] == ["server.database.post_item"] * 3
+        assert [r["params"]["key"] for r in requests] == [
+            DB_KEY_TIP_STATE,
+            DB_KEY_HAS_LIQUID,
+            DB_KEY_CURRENT_LIQUID,
+        ]
+        assert [r["params"]["value"] for r in requests] == ["attached", True, "water"]
+        assert all(r["params"]["namespace"] == DB_NAMESPACE for r in requests)
+
+    def test_current_liquid_none_is_persisted_as_none(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.save_tip_liquid_state("none", False, None)
+
+        requests = fake_websocket_client.sent_requests
+        assert requests[2]["params"]["value"] is None
+
+
+class TestLoadTipPresence:
+    def test_returns_stored_mapping(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        snapshot = {"tipbox_a": {"consumed": ["A1"], "rows": 8, "cols": 12}}
+        fake_websocket_client.queue_response({"result": {"value": snapshot}})
+        tracker = _tracker(fake_websocket_client)
+
+        result = tracker.load_tip_presence()
+
+        assert result == snapshot
+        request = fake_websocket_client.sent_requests[0]
+        assert request["method"] == "server.database.get_item"
+        assert request["params"] == {
+            "namespace": DB_NAMESPACE,
+            "key": DB_KEY_TIP_PRESENCE,
+        }
+
+    def test_returns_empty_dict_on_first_run(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({})
+        tracker = _tracker(fake_websocket_client)
+
+        assert tracker.load_tip_presence() == {}
+
+    def test_returns_empty_dict_when_stored_value_is_not_a_mapping(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        fake_websocket_client.queue_response({
+            "result": {"value": ["not", "a", "dict"]}
+        })
+        tracker = _tracker(fake_websocket_client)
+
+        assert tracker.load_tip_presence() == {}
+
+
+class TestSaveTipPresence:
+    def test_posts_the_snapshot_under_the_tip_presence_key(
+        self, fake_websocket_client: FakeWebSocketClient
+    ) -> None:
+        snapshot = {"tipbox_a": {"consumed": ["A1", "A2"], "rows": 8, "cols": 12}}
+        tracker = _tracker(fake_websocket_client)
+
+        tracker.save_tip_presence(snapshot)
+
+        assert len(fake_websocket_client.sent_requests) == 1
+        request = fake_websocket_client.sent_requests[0]
+        assert request["method"] == "server.database.post_item"
+        assert request["params"] == {
+            "namespace": DB_NAMESPACE,
+            "key": DB_KEY_TIP_PRESENCE,
+            "value": snapshot,
+        }


### PR DESCRIPTION
## Summary
Gap-fill test coverage for the two daemon-layer files flagged in #41 as far below the rest of `daemon/`:

- `daemon/moonraker_state.py` (`MoonrakerStateTracker`): 26% → **100%**. Covers the `printer.objects.subscribe` handling for live `homed_axes`/`print_stats` tracking (initial subscribe response + live `notify_status_update` pushes, including malformed/empty-params edge cases), `print_state` change callbacks, and the tip/liquid + tip-presence persistence round trip through Moonraker's `server.database` API (including first-run/partial-state/non-mapping-value edge cases).
- `daemon/main.py` (the `tapd` entry point): 0% → **97%** (only the `if __name__ == "__main__":` guard is unexercised). Covers `parse_arguments`'s flags, `setup_logging`'s handler/level wiring, `_serve`'s config-path resolution and `--no-connect`/`--local-connect` flag forwarding into `AutoPipetteService`, and `main()`'s exit-code handling for each caught exception type (`FileNotFoundError`/`ValueError` → 1, `KeyboardInterrupt` → 130, other `Exception` → 1, success → 0).

No new test infrastructure: `test_moonraker_state.py` reuses the existing `fake_websocket_client` fixture + a real `MoonrakerRequests`, matching the fakes-at-the-Moonraker-boundary style already used throughout `tests/daemon/`. `test_main.py` monkeypatches `AutoPipetteService`/`ControlServer` with tiny in-process fakes; its `_serve` tests exercise the real SIGINT/SIGTERM-driven shutdown path by having the fake `ControlServer.start()` self-send `SIGTERM` shortly after "starting" (scheduled on the same running loop, so there's no cross-thread race with the signal handler `_serve` registers before calling `start()`).

Full suite: 598 passed.

Closes #41.