### PR TITLE
Gap-fill test coverage for core/ modules below ~90%

### DIFF
--- a/tests/core/test_config_validation.py
+++ b/tests/core/test_config_validation.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``core/config_validation.py``'s ``validate_config_files``.
+
+Monkeypatches the module's ``DIR_CONFIG_*``/``CONFIG_SYSTEM`` constants to a
+``tmp_path`` tree rather than touching the repo's real ``config/`` directory,
+so these tests can freely create missing files, wrong-type paths (a
+directory where a file is expected), etc.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from tricca_autopipette.core import config_validation
+
+
+@pytest.fixture
+def config_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    """Redirect every ``DIR_CONFIG_*`` constant into an isolated ``tmp_path`` tree.
+
+    Returns:
+        Mapping of config kind (``"system"``/``"gantry"``/``"pipette"``/
+        ``"locations"``/``"liquids"``) to its (already-created, empty)
+        directory under ``tmp_path``.
+    """
+    dirs = {
+        "system": tmp_path / "system",
+        "gantry": tmp_path / "gantry",
+        "pipette": tmp_path / "pipettes",
+        "locations": tmp_path / "locations",
+        "liquids": tmp_path / "liquids",
+    }
+    for directory in dirs.values():
+        directory.mkdir()
+    monkeypatch.setattr(config_validation, "DIR_CONFIG_SYSTEM", dirs["system"])
+    monkeypatch.setattr(config_validation, "DIR_CONFIG_GANTRY", dirs["gantry"])
+    monkeypatch.setattr(config_validation, "DIR_CONFIG_PIPETTE", dirs["pipette"])
+    monkeypatch.setattr(config_validation, "DIR_CONFIG_LOCATIONS", dirs["locations"])
+    monkeypatch.setattr(config_validation, "DIR_CONFIG_LIQUIDS", dirs["liquids"])
+    monkeypatch.setattr(config_validation, "CONFIG_SYSTEM", "default_system.json")
+    return dirs
+
+
+def _validate(**overrides: str | None) -> None:
+    defaults: dict[str, str | None] = {
+        "config_system": None,
+        "config_gantry": None,
+        "config_pipette": None,
+        "config_locations": None,
+        "config_liquids": None,
+    }
+    defaults.update(overrides)
+    config_validation.validate_config_files(**defaults)  # type: ignore[arg-type]
+
+
+class TestSystemConfig:
+    def test_missing_default_system_file_raises(
+        self, config_dirs: dict[str, Path]
+    ) -> None:
+        with pytest.raises(FileNotFoundError, match=re.escape("default_system.json")):
+            _validate()
+
+    def test_default_system_file_present_passes(
+        self, config_dirs: dict[str, Path]
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+
+        _validate()  # must not raise
+
+    def test_explicit_system_filename_resolves_under_the_system_dir(
+        self, config_dirs: dict[str, Path]
+    ) -> None:
+        (config_dirs["system"] / "custom.json").write_text("{}")
+
+        _validate(config_system="custom.json")  # must not raise
+
+    def test_missing_explicit_system_file_raises(
+        self, config_dirs: dict[str, Path]
+    ) -> None:
+        with pytest.raises(FileNotFoundError, match=re.escape("missing.json")):
+            _validate(config_system="missing.json")
+
+    def test_system_path_that_is_a_directory_raises_value_error(
+        self, config_dirs: dict[str, Path]
+    ) -> None:
+        (config_dirs["system"] / "a_directory.json").mkdir()
+
+        with pytest.raises(ValueError, match="not a file"):
+            _validate(config_system="a_directory.json")
+
+
+@pytest.mark.parametrize(
+    ("kwarg", "dir_key"),
+    [
+        ("config_gantry", "gantry"),
+        ("config_pipette", "pipette"),
+        ("config_locations", "locations"),
+        ("config_liquids", "liquids"),
+    ],
+)
+class TestOptionalConfigs:
+    def test_none_is_skipped_entirely(
+        self, config_dirs: dict[str, Path], kwarg: str, dir_key: str
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+        # The optional dir stays empty -- if validation tried to check it
+        # anyway, this would raise.
+
+        _validate(**{kwarg: None})  # must not raise
+
+    def test_missing_named_file_raises(
+        self, config_dirs: dict[str, Path], kwarg: str, dir_key: str
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+
+        with pytest.raises(FileNotFoundError, match=re.escape("nope.json")):
+            _validate(**{kwarg: "nope.json"})
+
+    def test_present_named_file_passes(
+        self, config_dirs: dict[str, Path], kwarg: str, dir_key: str
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+        (config_dirs[dir_key] / "present.json").write_text("{}")
+
+        _validate(**{kwarg: "present.json"})  # must not raise
+
+    def test_path_that_is_a_directory_raises_value_error(
+        self, config_dirs: dict[str, Path], kwarg: str, dir_key: str
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+        (config_dirs[dir_key] / "a_directory.json").mkdir()
+
+        with pytest.raises(ValueError, match="not a file"):
+            _validate(**{kwarg: "a_directory.json"})
+
+
+class TestLogging:
+    def test_logs_info_for_every_validated_file(
+        self,
+        config_dirs: dict[str, Path],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        (config_dirs["system"] / "default_system.json").write_text("{}")
+        (config_dirs["gantry"] / "g.json").write_text("{}")
+
+        with caplog.at_level(logging.INFO):
+            _validate(config_gantry="g.json")
+
+        messages = [r.message for r in caplog.records]
+        assert any("default_system.json" in m for m in messages)
+        assert any("g.json" in m for m in messages)

--- a/tests/core/test_coordinate.py
+++ b/tests/core/test_coordinate.py
@@ -1,0 +1,200 @@
+"""Unit tests for ``core/coordinate.py``'s ``Coordinate``."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from tricca_autopipette.core.coordinate import Coordinate
+
+
+class TestConstruction:
+    def test_negative_x_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Coordinate(x=-1.0, y=0.0, z=0.0)
+
+    def test_negative_y_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Coordinate(x=0.0, y=-1.0, z=0.0)
+
+    def test_negative_z_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Coordinate(x=0.0, y=0.0, z=-1.0)
+
+    def test_zero_is_allowed(self) -> None:
+        coord = Coordinate(x=0.0, y=0.0, z=0.0)
+        assert coord.x == 0.0  # ruff:ignore[float-equality-comparison]
+
+
+class TestReprAndStr:
+    def test_repr(self) -> None:
+        coord = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert repr(coord) == "Coordinate(x=1.0, y=2.0, z=3.0)"
+
+    def test_str_formats_to_two_decimal_places(self) -> None:
+        coord = Coordinate(x=1.5, y=2.25, z=3.14159)
+        assert str(coord) == "(1.50, 2.25, 3.14)"
+
+
+class TestEqualityAndHash:
+    def test_equal_coordinates_compare_equal(self) -> None:
+        assert Coordinate(x=1.0, y=2.0, z=3.0) == Coordinate(x=1.0, y=2.0, z=3.0)
+
+    def test_different_coordinates_compare_unequal(self) -> None:
+        assert Coordinate(x=1.0, y=2.0, z=3.0) != Coordinate(x=1.0, y=2.0, z=4.0)
+
+    def test_comparison_with_non_coordinate_is_not_implemented(self) -> None:
+        coord = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert coord.__eq__("not a coordinate") is NotImplemented
+        assert coord != "not a coordinate"
+
+    def test_equal_coordinates_hash_equal(self) -> None:
+        a = Coordinate(x=1.0, y=2.0, z=3.0)
+        b = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert hash(a) == hash(b)
+
+    def test_usable_as_a_set_member(self) -> None:
+        a = Coordinate(x=1.0, y=2.0, z=3.0)
+        b = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert len({a, b}) == 1
+
+
+class TestGenerateOffset:
+    def test_applies_each_axis_independently(self) -> None:
+        coord = Coordinate(x=10.0, y=20.0, z=5.0)
+        offset = coord.generate_offset(dx=5.0, dy=-5.0, dz=2.0)
+        assert offset == Coordinate(x=15.0, y=15.0, z=7.0)
+
+    def test_does_not_mutate_the_original(self) -> None:
+        coord = Coordinate(x=10.0, y=20.0, z=5.0)
+        coord.generate_offset(dx=5.0)
+        assert coord == Coordinate(x=10.0, y=20.0, z=5.0)
+
+    def test_default_offsets_are_zero(self) -> None:
+        coord = Coordinate(x=10.0, y=20.0, z=5.0)
+        assert coord.generate_offset() == coord
+
+    def test_negative_result_raises(self) -> None:
+        coord = Coordinate(x=1.0, y=1.0, z=1.0)
+        with pytest.raises(ValueError, match="negative values"):
+            coord.generate_offset(dx=-5.0)
+
+
+class TestDistanceTo:
+    def test_euclidean_distance(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=0.0)
+        b = Coordinate(x=3.0, y=4.0, z=0.0)
+        assert a.distance_to(b) == pytest.approx(5.0)
+
+    def test_distance_to_self_is_zero(self) -> None:
+        coord = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert coord.distance_to(coord) == pytest.approx(0.0)
+
+    def test_includes_the_z_axis(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=0.0)
+        b = Coordinate(x=0.0, y=0.0, z=5.0)
+        assert a.distance_to(b) == pytest.approx(5.0)
+
+    def test_matches_manual_computation(self) -> None:
+        a = Coordinate(x=1.0, y=2.0, z=3.0)
+        b = Coordinate(x=4.0, y=6.0, z=15.0)
+        expected = math.sqrt((4 - 1) ** 2 + (6 - 2) ** 2 + (15 - 3) ** 2)
+        assert a.distance_to(b) == pytest.approx(expected)
+
+
+class TestDistanceXy:
+    def test_ignores_the_z_axis(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=10.0)
+        b = Coordinate(x=3.0, y=4.0, z=20.0)
+        assert a.distance_xy(b) == pytest.approx(5.0)
+
+    def test_zero_when_only_z_differs(self) -> None:
+        a = Coordinate(x=1.0, y=1.0, z=0.0)
+        b = Coordinate(x=1.0, y=1.0, z=99.0)
+        assert a.distance_xy(b) == pytest.approx(0.0)
+
+
+class TestIsAboveBelow:
+    def test_is_above_true_beyond_tolerance(self) -> None:
+        higher = Coordinate(x=10.0, y=10.0, z=15.0)
+        lower = Coordinate(x=10.0, y=10.0, z=10.0)
+        assert higher.is_above(lower) is True
+
+    def test_is_above_false_within_tolerance(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=10.005)
+        b = Coordinate(x=0.0, y=0.0, z=10.0)
+        assert a.is_above(b, tolerance=0.01) is False
+
+    def test_is_above_false_when_equal_or_lower(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=5.0)
+        b = Coordinate(x=0.0, y=0.0, z=10.0)
+        assert a.is_above(b) is False
+
+    def test_is_below_true_beyond_tolerance(self) -> None:
+        lower = Coordinate(x=10.0, y=10.0, z=10.0)
+        higher = Coordinate(x=10.0, y=10.0, z=15.0)
+        assert lower.is_below(higher) is True
+
+    def test_is_below_false_within_tolerance(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=9.995)
+        b = Coordinate(x=0.0, y=0.0, z=10.0)
+        assert a.is_below(b, tolerance=0.01) is False
+
+    def test_is_below_false_when_equal_or_higher(self) -> None:
+        a = Coordinate(x=0.0, y=0.0, z=10.0)
+        b = Coordinate(x=0.0, y=0.0, z=5.0)
+        assert a.is_below(b) is False
+
+
+class TestIsWithinBounds:
+    def test_inside_bounds(self) -> None:
+        coord = Coordinate(x=5.0, y=5.0, z=5.0)
+        assert coord.is_within_bounds(Coordinate.origin(), Coordinate(x=10, y=10, z=10))
+
+    def test_on_the_boundary_is_inclusive(self) -> None:
+        coord = Coordinate(x=10.0, y=10.0, z=10.0)
+        assert coord.is_within_bounds(Coordinate.origin(), Coordinate(x=10, y=10, z=10))
+
+    def test_outside_any_single_axis_fails(self) -> None:
+        coord = Coordinate(x=11.0, y=5.0, z=5.0)
+        assert not coord.is_within_bounds(
+            Coordinate.origin(), Coordinate(x=10, y=10, z=10)
+        )
+
+
+class TestClamp:
+    def test_clamps_each_axis_independently(self) -> None:
+        coord = Coordinate(x=15.0, y=5.0, z=0.0)
+        clamped = coord.clamp(Coordinate(x=0, y=0, z=2), Coordinate(x=10, y=10, z=10))
+        assert clamped == Coordinate(x=10.0, y=5.0, z=2.0)
+
+    def test_value_already_within_bounds_is_unchanged(self) -> None:
+        coord = Coordinate(x=5.0, y=5.0, z=5.0)
+        clamped = coord.clamp(Coordinate.origin(), Coordinate(x=10, y=10, z=10))
+        assert clamped == coord
+
+    def test_does_not_mutate_the_original(self) -> None:
+        coord = Coordinate(x=15.0, y=5.0, z=5.0)
+        coord.clamp(Coordinate.origin(), Coordinate(x=10, y=10, z=10))
+        assert coord == Coordinate(x=15.0, y=5.0, z=5.0)
+
+
+class TestOrigin:
+    def test_returns_zero_zero_zero(self) -> None:
+        assert Coordinate.origin() == Coordinate(x=0.0, y=0.0, z=0.0)
+
+
+class TestToFromTuple:
+    def test_to_tuple(self) -> None:
+        coord = Coordinate(x=1.0, y=2.0, z=3.0)
+        assert coord.to_tuple() == (1.0, 2.0, 3.0)
+
+    def test_from_tuple(self) -> None:
+        coord = Coordinate.from_tuple((1.0, 2.0, 3.0))
+        assert coord == Coordinate(x=1.0, y=2.0, z=3.0)
+
+    def test_round_trips(self) -> None:
+        original = Coordinate(x=7.5, y=8.5, z=9.5)
+        assert Coordinate.from_tuple(original.to_tuple()) == original

--- a/tests/core/test_gcode_buffer.py
+++ b/tests/core/test_gcode_buffer.py
@@ -1,0 +1,174 @@
+"""Unit tests for ``core/gcode_buffer.py``'s ``GCodeBuffer``."""
+
+from __future__ import annotations
+
+from tricca_autopipette.core.gcode_buffer import GCodeBuffer
+
+
+class TestAddAndGetCommands:
+    def test_get_commands_returns_added_commands_in_order(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add("G1 X10 Y10 F5000\n")
+
+        assert buffer.get_commands() == ["G28\n", "G1 X10 Y10 F5000\n"]
+
+    def test_get_commands_clears_the_buffer(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.get_commands()
+
+        assert buffer.get_commands() == []
+
+    def test_empty_buffer_returns_empty_list(self) -> None:
+        assert GCodeBuffer().get_commands() == []
+
+
+class TestHeader:
+    def test_get_header_returns_added_lines_in_order(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add_header("; a\n")
+        buffer.add_header("; b\n")
+
+        assert buffer.get_header() == ["; a\n", "; b\n"]
+
+    def test_get_header_does_not_clear(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add_header("; a\n")
+        buffer.get_header()
+
+        assert buffer.get_header() == ["; a\n"]
+
+
+class TestClearing:
+    def test_clear_commands_empties_only_commands(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add_header("; a\n")
+
+        buffer.clear_commands()
+
+        assert buffer.peek_commands() == []
+        assert buffer.get_header() == ["; a\n"]
+
+    def test_clear_header_empties_only_header(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add_header("; a\n")
+
+        buffer.clear_header()
+
+        assert buffer.get_header() == []
+        assert buffer.peek_commands() == ["G28\n"]
+
+    def test_clear_all_empties_both(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add_header("; a\n")
+
+        buffer.clear_all()
+
+        assert buffer.get_header() == []
+        assert buffer.peek_commands() == []
+
+
+class TestHasCommandsAndCount:
+    def test_has_commands_false_when_empty(self) -> None:
+        assert GCodeBuffer().has_commands() is False
+
+    def test_has_commands_true_after_add(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        assert buffer.has_commands() is True
+
+    def test_command_count_reflects_buffer_size(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add("G1 X10\n")
+        assert buffer.command_count() == 2
+
+    def test_command_count_zero_when_empty(self) -> None:
+        assert GCodeBuffer().command_count() == 0
+
+
+class TestPeekCommands:
+    def test_peek_does_not_clear(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+
+        peeked = buffer.peek_commands()
+
+        assert peeked == ["G28\n"]
+        assert buffer.get_commands() == ["G28\n"]
+
+    def test_peek_returns_a_copy(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+
+        peeked = buffer.peek_commands()
+        peeked.append("G1 X10\n")
+
+        assert buffer.peek_commands() == ["G28\n"]
+
+
+class TestBuildHeaderFromConfig:
+    def test_builds_a_formatted_header(self) -> None:
+        buffer = GCodeBuffer()
+        sections = {
+            "SPEED": {"SPEED_XY": "5000", "SPEED_Z": "2000"},
+            "SERVO": {"ANGLE_RETRACT": "160"},
+        }
+
+        buffer.build_header_from_config("auto.conf", sections)
+
+        header = buffer.get_header()
+        assert header[0] == "; Configuration: auto.conf\n"
+        assert header[1] == "; Settings:\n"
+        assert "; [SPEED]\n" in header
+        assert ";\t SPEED_XY = 5000\n" in header
+        assert ";\t SPEED_Z = 2000\n" in header
+        assert "; [SERVO]\n" in header
+        assert ";\t ANGLE_RETRACT = 160\n" in header
+
+    def test_replaces_rather_than_appends_to_existing_header(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add_header("; stale\n")
+
+        buffer.build_header_from_config("auto.conf", {})
+
+        assert "; stale\n" not in buffer.get_header()
+
+    def test_empty_sections_still_produces_the_preamble(self) -> None:
+        buffer = GCodeBuffer()
+
+        buffer.build_header_from_config("auto.conf", {})
+
+        assert buffer.get_header() == [
+            "; Configuration: auto.conf\n",
+            "; Settings:\n",
+        ]
+
+
+class TestDunderMethods:
+    def test_len_reflects_command_count(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        assert len(buffer) == 1
+
+    def test_bool_false_when_empty(self) -> None:
+        assert bool(GCodeBuffer()) is False
+
+    def test_bool_true_when_commands_present(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        assert bool(buffer) is True
+
+    def test_repr_shows_command_and_header_counts(self) -> None:
+        buffer = GCodeBuffer()
+        buffer.add("G28\n")
+        buffer.add_header("; a\n")
+
+        assert repr(buffer) == "GCodeBuffer(commands=1, header=1)"
+
+    def test_repr_on_empty_buffer(self) -> None:
+        assert repr(GCodeBuffer()) == "GCodeBuffer(commands=0, header=0)"

--- a/tests/core/test_json_config_manager.py
+++ b/tests/core/test_json_config_manager.py
@@ -1,25 +1,37 @@
-"""Tests for system-config inheritance and the ``locations`` section.
+"""Tests for ``JsonConfigManager``: loading, merging, and gap-fill coverage.
 
 ``extends`` exists so a per-protocol system config carries only what differs --
 usually just ``locations`` -- instead of duplicating gantry, network, and
 pipette settings that would then drift out of sync with the machine's.
 
-These tests write scratch config files into the real ``config/system/``
-directory (there is no injection point for it -- `JsonConfigManager` resolves
-against `DefaultPaths.DIR_CONFIG_SYSTEM` at call time) and remove them
-afterwards, so filenames are prefixed to avoid colliding with real configs.
+These tests write scratch config files into the real ``config/system/``,
+``config/gantry/``, ``config/pipettes/``, and ``config/liquids/`` directories
+(there is no injection point for them -- `JsonConfigManager` resolves against
+`DefaultPaths.DIR_CONFIG_*` at call time) and remove them afterwards, so
+filenames are prefixed to avoid colliding with real configs. The handful of
+tests that need a *missing* directory (`_load_default_pipettes`/
+`_load_default_liquids`'s "directory not found" branches, and the
+`_load_default_gantry` `FileNotFoundError`) monkeypatch the relevant
+`DefaultPaths.DIR_CONFIG_*` constant to an isolated `tmp_path` instead, since
+that can't be expressed by adding scratch files to a directory that already
+exists and already has real defaults in it.
 """
 
 from __future__ import annotations
 
+import itertools
 import json
+import logging
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from tricca_autopipette.core.json_config_manager import JsonConfigManager
+from tricca_autopipette.core.json_config_manager import (
+    MAX_EXTENDS_DEPTH,
+    JsonConfigManager,
+)
 from tricca_autopipette.core.pipette_constants import DefaultPaths
 from tricca_autopipette.core.pipette_models import LocationsConfig
 
@@ -36,14 +48,17 @@ _NORMALIZATION_CASES: list[tuple[Any, list[Any]]] = [
 ]
 
 
-@pytest.fixture
-def write_system_config() -> Iterator[Any]:
-    """Write scratch system configs, cleaning them up afterwards."""
+def _scratch_writer(directory: Path) -> Iterator[Any]:
+    """Shared body for the ``write_*_config`` fixtures below.
+
+    Yields a ``(name, payload) -> filename`` writer that prefixes each
+    filename and tracks it for cleanup once the test using it finishes.
+    """
     written: list[Path] = []
 
     def _write(name: str, payload: dict[str, Any]) -> str:
         filename = f"{PREFIX}{name}"
-        path = DefaultPaths.DIR_CONFIG_SYSTEM / filename
+        path = directory / filename
         path.write_text(json.dumps(payload), encoding="utf-8")
         written.append(path)
         return filename
@@ -52,6 +67,30 @@ def write_system_config() -> Iterator[Any]:
 
     for path in written:
         path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def write_system_config() -> Iterator[Any]:
+    """Write scratch system configs, cleaning them up afterwards."""
+    yield from _scratch_writer(DefaultPaths.DIR_CONFIG_SYSTEM)
+
+
+@pytest.fixture
+def write_gantry_config() -> Iterator[Any]:
+    """Write scratch gantry configs, cleaning them up afterwards."""
+    yield from _scratch_writer(DefaultPaths.DIR_CONFIG_GANTRY)
+
+
+@pytest.fixture
+def write_pipette_config() -> Iterator[Any]:
+    """Write scratch pipette configs, cleaning them up afterwards."""
+    yield from _scratch_writer(DefaultPaths.DIR_CONFIG_PIPETTE)
+
+
+@pytest.fixture
+def write_liquid_config() -> Iterator[Any]:
+    """Write scratch liquid configs, cleaning them up afterwards."""
+    yield from _scratch_writer(DefaultPaths.DIR_CONFIG_LIQUIDS)
 
 
 class TestExtends:
@@ -247,3 +286,499 @@ class TestLocationsConfigNormalization:
             LocationsConfig.model_validate(original.model_dump()).sources
             == original.sources
         )
+
+
+class TestGetSystemConfig:
+    def test_raises_without_a_loaded_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system configuration loaded"):
+            JsonConfigManager().get_system_config()
+
+    def test_returns_the_loaded_config(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        assert manager.get_system_config() is manager.system_config
+
+
+class TestLoadConfigs:
+    """``load_configs`` only dynamically re-loads gantry/pipette/liquids when
+
+    their filename differs from the module's own default constant --
+    otherwise ``load_system_config`` alone already covered it.
+    """
+
+    def test_default_filenames_load_only_the_system_config(self) -> None:
+        manager = JsonConfigManager()
+
+        config = manager.load_configs()
+
+        assert config is manager.system_config
+
+    def test_custom_gantry_filename_triggers_a_dynamic_load(
+        self, write_gantry_config: Any
+    ) -> None:
+        gantry_name = write_gantry_config("gantry.json", {"speed_xy": 4242.0})
+        manager = JsonConfigManager()
+
+        manager.load_configs(fn_gantry=gantry_name)
+
+        assert manager.system_config is not None
+        # Exact JSON round-trip of a literal, not a computed value.
+        assert manager.system_config.gantry.speed_xy == 4242.0  # ruff:ignore[float-equality-comparison]
+
+    def test_custom_pipette_filename_triggers_a_dynamic_load(
+        self, write_pipette_config: Any
+    ) -> None:
+        pipette_name = write_pipette_config(
+            "pipette.json", {"name": "Custom", "syringe": {}, "servo": {}}
+        )
+        manager = JsonConfigManager()
+
+        manager.load_configs(fn_pipette=pipette_name)
+
+        assert manager.system_config is not None
+        assert manager.system_config.pipette.name == "Custom"
+
+    def test_custom_liquids_filename_triggers_a_dynamic_load(
+        self, write_liquid_config: Any
+    ) -> None:
+        liquid_name = write_liquid_config("liquid.json", {"name": "extra_liquid"})
+        manager = JsonConfigManager()
+
+        manager.load_configs(fn_liquids=liquid_name)
+
+        assert manager.system_config is not None
+        assert "extra_liquid" in manager.system_config.liquids
+
+
+class TestLoadSystemConfigMissingFile:
+    def test_missing_top_level_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError, match="System config not found"):
+            JsonConfigManager().load_system_config(f"{PREFIX}does_not_exist.json")
+
+
+class TestPipetteResolution:
+    def test_unknown_pipette_reference_raises(self, write_system_config: Any) -> None:
+        child = write_system_config(
+            "bad_pipette.json", {"pipette": "not_a_real_pipette"}
+        )
+
+        with pytest.raises(ValueError, match="Unknown pipette"):
+            JsonConfigManager().load_system_config(child)
+
+    def test_inline_full_pipette_config_is_used_directly(
+        self, write_system_config: Any
+    ) -> None:
+        inline_pipette: dict[str, Any] = {
+            "name": "InlinePipette",
+            "syringe": {},
+            "servo": {},
+        }
+        child = write_system_config("inline_pipette.json", {"pipette": inline_pipette})
+
+        config = JsonConfigManager().load_system_config(child)
+
+        assert config.pipette.name == "InlinePipette"
+
+
+class TestLiquidMerging:
+    def test_user_only_liquid_is_added_alongside_defaults(
+        self, write_system_config: Any
+    ) -> None:
+        child = write_system_config(
+            "extra_liquid.json",
+            {
+                "pipette": "p100_vertical",
+                "liquids": {"my_custom_liquid": {"name": "my_custom_liquid"}},
+            },
+        )
+
+        config = JsonConfigManager().load_system_config(child)
+
+        assert "my_custom_liquid" in config.liquids
+        assert "water" in config.liquids  # defaults are still present
+
+
+class TestExtendsDepthGuard:
+    def test_chain_deeper_than_max_depth_raises(self, write_system_config: Any) -> None:
+        # Build a straight (acyclic) chain one link longer than
+        # MAX_EXTENDS_DEPTH, so the depth guard trips rather than the cycle
+        # guard. The file the last link's `extends` points to is never
+        # actually read (the guard fires before that read), so it need not
+        # exist.
+        names = [
+            write_system_config(f"depth_{i}.json", {})
+            for i in range(MAX_EXTENDS_DEPTH + 1)
+        ]
+        for child_name, parent_name in itertools.pairwise(names):
+            path = DefaultPaths.DIR_CONFIG_SYSTEM / child_name
+            path.write_text(json.dumps({"extends": parent_name}))
+        last_path = DefaultPaths.DIR_CONFIG_SYSTEM / names[-1]
+        last_path.write_text(json.dumps({"extends": "unreachable.json"}))
+
+        with pytest.raises(ValueError, match="deeper than"):
+            JsonConfigManager().load_system_config(names[0])
+
+
+class TestExtendsValidation:
+    def test_non_string_extends_in_an_ancestor_raises(
+        self, write_system_config: Any
+    ) -> None:
+        write_system_config("mid.json", {"extends": 123})
+        child = write_system_config("child.json", {"extends": f"{PREFIX}mid.json"})
+
+        with pytest.raises(ValueError, match="must be a filename string"):
+            JsonConfigManager().load_system_config(child)
+
+
+class TestReadSystemFile:
+    def test_invalid_json_raises_value_error(self) -> None:
+        path = DefaultPaths.DIR_CONFIG_SYSTEM / f"{PREFIX}invalid.json"
+        path.write_text("{not valid json")
+        try:
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                JsonConfigManager().load_system_config(path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_non_object_json_raises_value_error(self) -> None:
+        path = DefaultPaths.DIR_CONFIG_SYSTEM / f"{PREFIX}array.json"
+        path.write_text("[1, 2, 3]")
+        try:
+            with pytest.raises(ValueError, match="must contain a JSON object"):
+                JsonConfigManager().load_system_config(path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestLoadGantry:
+    def test_raises_without_a_loaded_system_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().load_gantry()
+
+    def test_missing_file_raises(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        with pytest.raises(FileNotFoundError, match="Gantry config not found"):
+            manager.load_gantry(f"{PREFIX}does_not_exist.json")
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        path = DefaultPaths.DIR_CONFIG_GANTRY / f"{PREFIX}invalid.json"
+        path.write_text("{not valid json")
+        try:
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                manager.load_gantry(path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_validation_failure_raises_value_error(
+        self, write_gantry_config: Any
+    ) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_gantry_config("bad.json", {"speed_xy": -1.0})  # gt=0 violated
+
+        with pytest.raises(ValueError, match="Gantry config validation failed"):
+            manager.load_gantry(name)
+
+    def test_success_updates_the_active_gantry(self, write_gantry_config: Any) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_gantry_config("fast.json", {"speed_xy": 9999.0})
+
+        gantry = manager.load_gantry(name)
+
+        # Exact JSON round-trip of a literal, not a computed value.
+        assert gantry.speed_xy == 9999.0  # ruff:ignore[float-equality-comparison]
+        assert manager.system_config is not None
+        assert manager.system_config.gantry is gantry
+
+
+class TestLoadPipette:
+    def test_raises_without_a_loaded_system_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().load_pipette()
+
+    def test_missing_file_raises(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        with pytest.raises(FileNotFoundError, match="Pipette config not found"):
+            manager.load_pipette(f"{PREFIX}does_not_exist.json")
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        path = DefaultPaths.DIR_CONFIG_PIPETTE / f"{PREFIX}invalid.json"
+        path.write_text("{not valid json")
+        try:
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                manager.load_pipette(path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_validation_failure_raises_value_error(
+        self, write_pipette_config: Any
+    ) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_pipette_config("bad.json", {"syringe": {}, "servo": {}})  # no name
+
+        with pytest.raises(ValueError, match="Pipette config validation failed"):
+            manager.load_pipette(name)
+
+    def test_success_updates_the_active_pipette(
+        self, write_pipette_config: Any
+    ) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_pipette_config(
+            "custom.json", {"name": "Custom", "syringe": {}, "servo": {}}
+        )
+
+        pipette = manager.load_pipette(name)
+
+        assert pipette.name == "Custom"
+        assert manager.system_config is not None
+        assert manager.system_config.pipette is pipette
+
+
+class TestLoadLiquid:
+    def test_raises_without_a_loaded_system_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().load_liquid()
+
+    def test_missing_file_raises(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        with pytest.raises(FileNotFoundError, match="Liquid config not found"):
+            manager.load_liquid(f"{PREFIX}does_not_exist.json")
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        path = DefaultPaths.DIR_CONFIG_LIQUIDS / f"{PREFIX}invalid.json"
+        path.write_text("{not valid json")
+        try:
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                manager.load_liquid(path.name)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_validation_failure_raises_value_error(
+        self, write_liquid_config: Any
+    ) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_liquid_config("bad.json", {})  # missing required "name"
+
+        with pytest.raises(ValueError, match="Liquid config validation failed"):
+            manager.load_liquid(name)
+
+    def test_success_adds_the_liquid_without_activating_it(
+        self, write_liquid_config: Any
+    ) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+        name = write_liquid_config("acetone.json", {"name": "acetone"})
+
+        liquid = manager.load_liquid(name)
+
+        assert liquid.name == "acetone"
+        assert manager.system_config is not None
+        assert manager.system_config.liquids["acetone"] is liquid
+
+
+class TestSwitchLiquid:
+    def test_raises_without_a_loaded_system_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().switch_liquid("water")
+
+    def test_unknown_liquid_raises_value_error(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        with pytest.raises(ValueError, match="not loaded"):
+            manager.switch_liquid("not_a_real_liquid")
+
+    def test_known_liquid_returns_its_profile(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        profile = manager.switch_liquid("water")
+
+        assert profile.name == "water"
+
+
+class TestGetActiveLiquidName:
+    def test_always_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError):
+            JsonConfigManager().get_active_liquid_name()
+
+
+class TestListAvailablePipettes:
+    def test_lists_real_default_pipette_file_stems(self) -> None:
+        pipettes = JsonConfigManager().list_available_pipettes()
+
+        assert pipettes == sorted(pipettes)
+        assert "p100_vertical" in pipettes
+
+    def test_missing_directory_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(
+            DefaultPaths, "DIR_CONFIG_PIPETTE", tmp_path / "does_not_exist"
+        )
+
+        assert JsonConfigManager().list_available_pipettes() == []
+
+
+class TestListAvailableLiquids:
+    def test_no_config_loaded_returns_empty_list(self) -> None:
+        assert JsonConfigManager().list_available_liquids() == []
+
+    def test_loaded_config_returns_sorted_liquid_names(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        liquids = manager.list_available_liquids()
+
+        assert liquids == sorted(liquids)
+        assert "water" in liquids
+
+
+class TestHasLiquid:
+    def test_no_config_loaded_returns_false(self) -> None:
+        assert JsonConfigManager().has_liquid("water") is False
+
+    def test_loaded_config_reports_presence(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        assert manager.has_liquid("water") is True
+        assert manager.has_liquid("not_a_real_liquid") is False
+
+
+class TestGetCurrentConfig:
+    def test_raises_without_a_loaded_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().get_current_config()
+
+    def test_returns_the_loaded_config(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        assert manager.get_current_config() is manager.system_config
+
+
+class TestGetMergedSyringeParamsErrors:
+    """The happy path is covered incidentally by `AutoPipette` fixtures --
+
+    only the two guard branches need direct coverage here.
+    """
+
+    def test_raises_without_a_loaded_config(self) -> None:
+        with pytest.raises(RuntimeError, match="No system config loaded"):
+            JsonConfigManager().get_merged_syringe_params("water")
+
+    def test_unknown_liquid_raises_value_error(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        with pytest.raises(ValueError, match="not found"):
+            manager.get_merged_syringe_params("not_a_real_liquid")
+
+
+class TestLoadDefaultGantry:
+    def test_missing_default_file_raises_file_not_found(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(DefaultPaths, "DIR_CONFIG_GANTRY", tmp_path)
+
+        with pytest.raises(FileNotFoundError, match="Default gantry"):
+            JsonConfigManager()._load_default_gantry()
+
+
+class TestLoadDefaultPipettes:
+    def test_missing_directory_returns_empty_and_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(
+            DefaultPaths, "DIR_CONFIG_PIPETTE", tmp_path / "does_not_exist"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = JsonConfigManager()._load_default_pipettes()
+
+        assert result == {}
+        assert any("not found" in r.message for r in caplog.records)
+
+    def test_a_malformed_file_is_skipped_and_logged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        (tmp_path / "good.json").write_text(
+            json.dumps({"name": "Good", "syringe": {}, "servo": {}})
+        )
+        (tmp_path / "bad.json").write_text("{not valid json")
+        monkeypatch.setattr(DefaultPaths, "DIR_CONFIG_PIPETTE", tmp_path)
+
+        with caplog.at_level(logging.ERROR):
+            result = JsonConfigManager()._load_default_pipettes()
+
+        assert set(result) == {"good"}
+        assert any("bad.json" in r.message for r in caplog.records)
+
+
+class TestLoadDefaultLiquids:
+    def test_missing_directory_returns_empty_and_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(
+            DefaultPaths, "DIR_CONFIG_LIQUIDS", tmp_path / "does_not_exist"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = JsonConfigManager()._load_default_liquids()
+
+        assert result == {}
+        assert any("not found" in r.message for r in caplog.records)
+
+    def test_a_malformed_file_is_skipped_and_logged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        (tmp_path / "good.json").write_text(json.dumps({"name": "good_liquid"}))
+        (tmp_path / "bad.json").write_text("{not valid json")
+        monkeypatch.setattr(DefaultPaths, "DIR_CONFIG_LIQUIDS", tmp_path)
+
+        with caplog.at_level(logging.ERROR):
+            result = JsonConfigManager()._load_default_liquids()
+
+        assert set(result) == {"good_liquid"}
+        assert any("bad.json" in r.message for r in caplog.records)
+
+
+class TestRepr:
+    def test_reflects_unloaded_state(self) -> None:
+        assert repr(JsonConfigManager()) == "JsonConfigManager(system_loaded=False)"
+
+    def test_reflects_loaded_state(self) -> None:
+        manager = JsonConfigManager()
+        manager.load_system_config()
+
+        assert repr(manager) == "JsonConfigManager(system_loaded=True)"

--- a/tests/core/test_location_manager.py
+++ b/tests/core/test_location_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +18,9 @@ import pytest
 
 from tricca_autopipette.core.coordinate import Coordinate
 from tricca_autopipette.core.location_manager import LocationManager
-from tricca_autopipette.core.plates import PlateParams, TipBox
+from tricca_autopipette.core.pipette_constants import DefaultPaths
+from tricca_autopipette.core.pipette_exceptions import NotALocationError
+from tricca_autopipette.core.plates import Plate, PlateFactory, PlateParams, TipBox
 from tricca_autopipette.core.well import StrategyType, Well
 
 
@@ -57,6 +60,21 @@ def _tipbox_entry(name: str, cols: int = 3, **extra: Any) -> dict[str, Any]:
         "num_row": 1,
         "num_col": cols,
         "spacing_col": 9.0,
+        "dip_top": 5.0,
+    }
+    entry.update(extra)
+    return entry
+
+
+def _array_entry(name: str, cols: int = 3, **extra: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "name": name,
+        "type": "array",
+        "x": 150.0,
+        "y": 20.0,
+        "z": 5.0,
+        "num_row": 1,
+        "num_col": cols,
         "dip_top": 5.0,
     }
     entry.update(extra)
@@ -584,3 +602,403 @@ class TestSaveRoundTrip:
         assert "order" not in entry
         assert "mask" not in entry
         assert "on_exhaust" not in entry
+
+    def test_custom_non_preset_order_is_saved_as_a_full_descriptor(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        """A combination that matches no preset name round-trips explicitly."""
+        _write(
+            locations_dir,
+            "t.json",
+            {"plates": [_array_entry("plate", order={"row_dir": "bottom_up"})]},
+        )
+        manager.load_from_json("t.json")
+
+        manager.save_to_json("out.json")
+
+        saved = json.loads((locations_dir / "out.json").read_text(encoding="utf-8"))
+        entry = saved["plates"][0]
+        assert entry["order"] == {
+            "major": "row",
+            "row_dir": "bottom_up",
+            "col_dir": "left_right",
+            "serpentine": False,
+        }
+
+    def test_non_default_on_exhaust_is_saved_for_a_non_tipbox_plate(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {"plates": [_array_entry("plate", on_exhaust="error")]},
+        )
+        manager.load_from_json("t.json")
+
+        manager.save_to_json("out.json")
+
+        saved = json.loads((locations_dir / "out.json").read_text(encoding="utf-8"))
+        entry = saved["plates"][0]
+        assert entry["on_exhaust"] == "error"
+
+
+# ==================== Plate-file references ====================
+
+
+class TestPlateFileReference:
+    """`plate_file` supplies geometry from a reusable template; the locations
+
+    entry supplies placement and any per-deck overrides. Uses the real
+    `config/plates/96_well_standard.json` template (read-only, like the
+    default system/pipette/liquid configs used elsewhere) rather than a
+    scratch file, since `location_manager.DIR_CONFIG_PLATES` isn't an
+    injection point.
+    """
+
+    def test_plate_file_supplies_geometry_and_entry_overrides_placement(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    {
+                        "name": "assay",
+                        "plate_file": "96_well_standard.json",
+                        "x": 150.0,
+                        "y": 20.0,
+                        "z": 5.0,
+                    }
+                ]
+            },
+        )
+
+        manager.load_from_json("t.json")
+
+        plate = manager.locations["assay"]
+        assert isinstance(plate, Plate)
+        assert plate.num_row == 8
+        assert plate.num_col == 12
+        # Placement from the entry, not the file; exact JSON round-trip of a
+        # literal, not a computed value.
+        assert plate.wells[0].coor.x == 150.0  # ruff:ignore[float-equality-comparison]
+
+    def test_dip_btm_and_well_diameter_round_trip(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    {
+                        "name": "assay",
+                        "plate_file": "96_well_standard.json",
+                        "x": 150.0,
+                        "y": 20.0,
+                        "z": 5.0,
+                    }
+                ]
+            },
+        )
+        manager.load_from_json("t.json")
+
+        manager.save_to_json("out.json")
+
+        saved = json.loads((locations_dir / "out.json").read_text(encoding="utf-8"))
+        entry = saved["plates"][0]
+        # Exact JSON round-trip of a literal, not a computed value.
+        assert entry["dip_btm"] == 11.0  # ruff:ignore[float-equality-comparison]
+        assert entry["well_diameter"] == 6.86  # ruff:ignore[float-equality-comparison]
+
+
+class TestPlateFileErrors:
+    def test_missing_plate_file_raises(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    {
+                        "name": "assay",
+                        "plate_file": "does_not_exist.json",
+                        "x": 0,
+                        "y": 0,
+                        "z": 0,
+                    }
+                ]
+            },
+        )
+
+        with pytest.raises(FileNotFoundError, match="Plate definition not found"):
+            manager.load_from_json("t.json")
+
+    def test_invalid_json_plate_file_raises(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        # `DIR_CONFIG_PLATES` isn't an injection point, so this scratch file
+        # is written into the real repo directory and removed afterwards,
+        # matching the convention `test_json_config_manager.py` established.
+        bad_file = DefaultPaths.DIR_CONFIG_PLATES / "pytest_tmp_bad_plate.json"
+        bad_file.write_text("{not valid json")
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    {
+                        "name": "assay",
+                        "plate_file": bad_file.name,
+                        "x": 0,
+                        "y": 0,
+                        "z": 0,
+                    }
+                ]
+            },
+        )
+
+        try:
+            with pytest.raises(ValueError, match="Invalid plate definition JSON"):
+                manager.load_from_json("t.json")
+        finally:
+            bad_file.unlink(missing_ok=True)
+
+
+# ==================== Tips-block validation ====================
+
+
+class TestTipsBlockValidation:
+    def test_malformed_tips_block_rejected(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {"plates": [_tipbox_entry("tips", tips=["not", "a", "dict"])]},
+        )
+
+        with pytest.raises(ValueError, match="malformed 'tips' block"):
+            manager.load_from_json("t.json")
+
+    def test_malformed_consumed_list_rejected(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {"plates": [_tipbox_entry("tips", tips={"consumed": "A1"})]},
+        )
+
+        with pytest.raises(
+            ValueError, match=re.escape("malformed 'tips.consumed' list")
+        ):
+            manager.load_from_json("t.json")
+
+    def test_out_of_bounds_range_rejected(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {"plates": [_tipbox_entry("tips", cols=3, tips={"consumed": ["Z99"]})]},
+        )
+
+        with pytest.raises(
+            ValueError, match=re.escape("Invalid 'tips.consumed' for plate 'tips'")
+        ):
+            manager.load_from_json("t.json")
+
+
+# ==================== load_spec / load_group(replace=True) ====================
+
+
+class TestLoadSpec:
+    def test_filename_source(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "a.json", _coord_file(["bench"]))
+
+        manager.load_spec(["a.json"])
+
+        assert manager.get_all_names() == ["bench"]
+        assert manager.source_of("bench") == "a.json"
+
+    def test_inline_payload_source(self, manager: LocationManager) -> None:
+        manager.load_spec([_coord_file(["inline_bench"])])
+
+        assert manager.get_all_names() == ["inline_bench"]
+        assert manager.source_of("inline_bench") == "<inline #1>"
+
+    def test_mixed_sources_apply_in_order(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "a.json", _coord_file(["bench"]))
+
+        manager.load_spec(["a.json", _coord_file(["sink"])])
+
+        assert sorted(manager.get_all_names()) == ["bench", "sink"]
+
+    def test_replace_clears_first(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "a.json", _coord_file(["bench"]))
+        manager.load_from_json("a.json")
+
+        manager.load_spec([_coord_file(["sink"])], replace=True)
+
+        assert manager.get_all_names() == ["sink"]
+
+    def test_missing_file_in_spec_raises_and_leaves_deck_untouched(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "a.json", _coord_file(["bench"]))
+        manager.load_from_json("a.json")
+
+        with pytest.raises(FileNotFoundError):
+            manager.load_spec(["a.json", "missing.json"])
+
+        assert manager.get_all_names() == ["bench"]
+
+
+class TestLoadGroupReplace:
+    def test_replace_clears_before_the_group(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "old.json", _coord_file(["stale"]))
+        manager.load_from_json("old.json")
+        _write(locations_dir, "a.json", _coord_file(["bench"]))
+        _write(locations_dir, "b.json", _coord_file(["sink"]))
+
+        manager.load_group(["a.json", "b.json"], replace=True)
+
+        assert sorted(manager.get_all_names()) == ["bench", "sink"]
+
+
+# ==================== get_coordinate row/col validation ====================
+
+
+class TestGetCoordinateRowColValidation:
+    def test_only_row_given_raises(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "t.json", {"plates": [_array_entry("plate")]})
+        manager.load_from_json("t.json")
+
+        with pytest.raises(ValueError, match="must be provided together"):
+            manager.get_coordinate("plate", row=0)
+
+    def test_only_col_given_raises(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "t.json", {"plates": [_array_entry("plate")]})
+        manager.load_from_json("t.json")
+
+        with pytest.raises(ValueError, match="must be provided together"):
+            manager.get_coordinate("plate", col=0)
+
+
+# ==================== set_plate factory-mismatch guards ====================
+
+
+class TestSetPlateTypeMismatch:
+    """Guards against a misregistered factory entry -- exercised here by
+
+    monkeypatching `PlateFactory.create` to return a plate of the wrong
+    class for the declared `plate_type`.
+    """
+
+    @staticmethod
+    def _well() -> Well:
+        return Well(
+            coor=Coordinate(x=0, y=0, z=0),
+            dip_top=5.0,
+            strategy_type=StrategyType.SIMPLE,
+        )
+
+    def _array_plate(self) -> Plate:
+        params = PlateParams(plate_type="array", well_template=self._well())
+        return PlateFactory.create(params)
+
+    def _stub_create(self, _params: PlateParams) -> Plate:
+        return self._wrong_plate
+
+    def test_waste_container_type_mismatch_raises(
+        self, manager: LocationManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._wrong_plate = self._array_plate()
+        monkeypatch.setattr(PlateFactory, "create", self._stub_create)
+        params = PlateParams(plate_type="waste_container", well_template=self._well())
+
+        with pytest.raises(TypeError, match="factory created"):
+            manager.set_plate("waste", params)
+
+    def test_tipbox_type_mismatch_raises(
+        self, manager: LocationManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._wrong_plate = self._array_plate()
+        monkeypatch.setattr(PlateFactory, "create", self._stub_create)
+        params = PlateParams(plate_type="tipbox", well_template=self._well())
+
+        with pytest.raises(TypeError, match="factory created"):
+            manager.set_plate("box", params)
+
+
+# ==================== get_location_info / __repr__ ====================
+
+
+class TestGetLocationInfo:
+    def test_unknown_location_raises(self, manager: LocationManager) -> None:
+        with pytest.raises(NotALocationError):
+            manager.get_location_info("nope")
+
+    def test_coordinate_info(self, manager: LocationManager) -> None:
+        manager.set_coordinate("home", Coordinate(x=1.0, y=2.0, z=3.0))
+
+        info = manager.get_location_info("home")
+
+        assert info == {"type": "coordinate", "x": "1.0", "y": "2.0", "z": "3.0"}
+
+    def test_plate_info_includes_current_position(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(locations_dir, "t.json", {"plates": [_array_entry("plate", cols=3)]})
+        manager.load_from_json("t.json")
+
+        info = manager.get_location_info("plate")
+
+        assert info["type"] == "plate"
+        assert info["rows"] == "1"
+        assert info["cols"] == "3"
+        assert "current_row" in info
+        assert "current_col" in info
+
+
+class TestRepr:
+    def test_reflects_empty_manager(self, manager: LocationManager) -> None:
+        assert repr(manager) == "LocationManager(locations=0, tipboxes=0, waste=no)"
+
+    def test_reflects_populated_manager(
+        self, manager: LocationManager, locations_dir: Path
+    ) -> None:
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    _tipbox_entry("tips"),
+                    {
+                        "name": "waste",
+                        "type": "waste_container",
+                        "x": 0,
+                        "y": 0,
+                        "z": 0,
+                    },
+                ]
+            },
+        )
+        manager.load_from_json("t.json")
+
+        assert repr(manager) == "LocationManager(locations=2, tipboxes=1, waste=yes)"

--- a/tests/core/test_pipette_exceptions.py
+++ b/tests/core/test_pipette_exceptions.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``core/pipette_exceptions.py``: message/attribute shape."""
+
+from __future__ import annotations
+
+from tricca_autopipette.core.pipette_exceptions import (
+    AutoPipetteError,
+    MissingConfigError,
+    NotADipStrategyError,
+    NotALocationError,
+    NotHomedError,
+    NoTipboxError,
+    NoWasteContainerError,
+    OutOfTipsError,
+    ProtocolAbortedError,
+    TipAlreadyOnError,
+    VolumeCapacityError,
+)
+
+
+class TestBaseException:
+    def test_is_a_plain_exception(self) -> None:
+        assert issubclass(AutoPipetteError, Exception)
+
+
+class TestTipAlreadyOnError:
+    def test_message(self) -> None:
+        err = TipAlreadyOnError()
+        assert str(err) == "Tip already attached. Eject current tip first."
+        assert isinstance(err, AutoPipetteError)
+
+
+class TestNotALocationError:
+    def test_message_and_attribute(self) -> None:
+        err = NotALocationError("bench")
+        assert err.location == "bench"
+        assert str(err) == "bench is not a named location."
+
+
+class TestNoTipboxError:
+    def test_message(self) -> None:
+        assert str(NoTipboxError()) == "No tipbox configured."
+
+
+class TestOutOfTipsError:
+    def test_message_names_the_checked_boxes(self) -> None:
+        err = OutOfTipsError(["box_a", "box_b"])
+        assert err.boxes == ["box_a", "box_b"]
+        assert str(err) == (
+            "No tips remaining in box_a, box_b. Reload and run reset_tips."
+        )
+
+    def test_message_falls_back_when_no_boxes_configured(self) -> None:
+        err = OutOfTipsError([])
+        assert str(err) == (
+            "No tips remaining in any configured tipbox. Reload and run reset_tips."
+        )
+
+
+class TestMissingConfigError:
+    def test_message_and_attributes(self) -> None:
+        err = MissingConfigError("SPEED", "/path/to/config.conf")
+        assert err.section == "SPEED"
+        assert err.conf_path == "/path/to/config.conf"
+        assert str(err) == "Missing section 'SPEED' in config: /path/to/config.conf"
+
+
+class TestNotADipStrategyError:
+    def test_message_with_valid_strategies(self) -> None:
+        err = NotADipStrategyError("invalid", ["simple", "cylinder"])
+        assert err.strategy == "invalid"
+        assert err.valid_strategies == ["simple", "cylinder"]
+        assert str(err) == (
+            "Invalid dip strategy 'invalid'. Valid options: ['simple', 'cylinder']"
+        )
+
+    def test_message_without_valid_strategies(self) -> None:
+        err = NotADipStrategyError("invalid")
+        assert err.valid_strategies is None
+        assert str(err) == "Invalid dip strategy 'invalid'."
+
+    def test_message_with_empty_valid_strategies_list(self) -> None:
+        """An empty list is falsy, same code path as None."""
+        err = NotADipStrategyError("invalid", [])
+        assert str(err) == "Invalid dip strategy 'invalid'."
+
+
+class TestNoWasteContainerError:
+    def test_message(self) -> None:
+        assert str(NoWasteContainerError()) == "No waste container configured."
+
+
+class TestVolumeCapacityError:
+    def test_message_and_attributes(self) -> None:
+        err = VolumeCapacityError(150.0, 98.0)
+        assert err.volume_ul == 150.0  # ruff:ignore[float-equality-comparison]
+        assert err.usable_ul == 98.0  # ruff:ignore[float-equality-comparison]
+        assert str(err) == (
+            "Cannot aspirate 150.0 μL: exceeds usable syringe capacity of 98.0 μL."
+        )
+
+
+class TestProtocolAbortedError:
+    def test_is_an_autopipette_error(self) -> None:
+        assert issubclass(ProtocolAbortedError, AutoPipetteError)
+
+    def test_can_carry_a_custom_message(self) -> None:
+        assert str(ProtocolAbortedError("user aborted")) == "user aborted"
+
+
+class TestNotHomedError:
+    def test_message_and_attribute(self) -> None:
+        err = NotHomedError("move")
+        assert err.command_name == "move"
+        assert str(err) == (
+            "Command 'move' blocked — pipette not homed. "
+            "Run 'init' or 'home all' first."
+        )

--- a/tests/core/test_pipette_models.py
+++ b/tests/core/test_pipette_models.py
@@ -1,0 +1,109 @@
+"""Unit tests for the gap-fill areas of ``core/pipette_models.py``.
+
+Most of this module is exercised incidentally by config-loading tests
+(``test_json_config_manager.py``) and ``autopipette`` fixtures; this file
+covers what those never happen to touch: ``PipetteState.has_tip``'s
+getter/setter, and the calibration-data validation shared (as duplicated
+logic) by ``PipetteSyringeKinematics`` and ``LiquidProfile``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tricca_autopipette.core.pipette_models import (
+    LiquidProfile,
+    PipetteState,
+    PipetteSyringeKinematics,
+    TipState,
+)
+
+
+class TestPipetteStateHasTip:
+    def test_true_when_attached(self) -> None:
+        state = PipetteState(tip_state=TipState.ATTACHED)
+        assert state.has_tip is True
+
+    def test_false_when_detached(self) -> None:
+        state = PipetteState(tip_state=TipState.DETACHED)
+        assert state.has_tip is False
+
+    def test_false_when_unknown(self) -> None:
+        """UNKNOWN is treated as False for safety."""
+        state = PipetteState(tip_state=TipState.UNKNOWN)
+        assert state.has_tip is False
+
+    def test_setter_true_sets_attached(self) -> None:
+        state = PipetteState()
+        state.has_tip = True
+        assert state.tip_state == TipState.ATTACHED
+
+    def test_setter_false_sets_detached(self) -> None:
+        state = PipetteState()
+        state.has_tip = False
+        assert state.tip_state == TipState.DETACHED
+
+
+class TestSyringeCalibrationValidation:
+    def test_both_omitted_is_valid(self) -> None:
+        PipetteSyringeKinematics()  # must not raise
+
+    def test_both_provided_is_valid(self) -> None:
+        PipetteSyringeKinematics(
+            calibration_volumes=[0.0, 100.0], calibration_steps=[0.0, 48.0]
+        )  # must not raise
+
+    def test_volumes_without_steps_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            PipetteSyringeKinematics(calibration_volumes=[0.0, 100.0])
+
+    def test_steps_without_volumes_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            PipetteSyringeKinematics(calibration_steps=[0.0, 48.0])
+
+    def test_mismatched_lengths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must have the same length"):
+            PipetteSyringeKinematics(
+                calibration_volumes=[0.0, 100.0, 200.0], calibration_steps=[0.0, 48.0]
+            )
+
+    def test_fewer_than_two_points_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="at least 2 points"):
+            PipetteSyringeKinematics(
+                calibration_volumes=[100.0], calibration_steps=[48.0]
+            )
+
+
+class TestLiquidCalibrationValidation:
+    def test_both_omitted_is_valid(self) -> None:
+        LiquidProfile(name="water")  # must not raise
+
+    def test_both_provided_is_valid(self) -> None:
+        LiquidProfile(
+            name="water",
+            calibration_volumes=[0.0, 100.0],
+            calibration_steps=[0.0, 48.0],
+        )  # must not raise
+
+    def test_volumes_without_steps_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            LiquidProfile(name="water", calibration_volumes=[0.0, 100.0])
+
+    def test_steps_without_volumes_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be provided together"):
+            LiquidProfile(name="water", calibration_steps=[0.0, 48.0])
+
+    def test_mismatched_lengths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must have the same length"):
+            LiquidProfile(
+                name="water",
+                calibration_volumes=[0.0, 100.0, 200.0],
+                calibration_steps=[0.0, 48.0],
+            )
+
+    def test_fewer_than_two_points_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="at least 2 points"):
+            LiquidProfile(
+                name="water", calibration_volumes=[100.0], calibration_steps=[48.0]
+            )

--- a/tests/core/test_plates.py
+++ b/tests/core/test_plates.py
@@ -313,3 +313,194 @@ def test_plate_is_abstract() -> None:
     """Plate stays abstract so every subclass defines its own traversal."""
     with pytest.raises(TypeError):
         Plate(_params())  # type: ignore[abstract]
+
+
+# ==================== PlateParams validation ====================
+
+
+class TestPlateParamsValidation:
+    def test_unregistered_plate_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid plate type"):
+            PlateParams(plate_type="not_a_real_type", well_template=_well())
+
+    def test_explicit_none_order_resolves_to_row_major(self) -> None:
+        params = PlateParams(
+            plate_type="array",
+            well_template=_well(),
+            order=None,  # pyright: ignore[reportArgumentType]
+        )
+        assert params.order == TraversalOrder()
+
+
+# ==================== Plate base-class dunders and helpers ====================
+
+
+class TestPlateDunders:
+    def test_repr(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert repr(plate) == "PlateArray(rows=2, cols=3, wells=6)"
+
+    def test_iter_yields_wells_in_row_major_order(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert list(plate) == plate.wells
+
+    def test_getitem_supports_negative_indexing(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert plate[-1] is plate.wells[-1]
+        assert plate[0] is plate.wells[0]
+
+
+class TestGetWell:
+    def test_valid_position_returns_the_well(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert plate.get_well(1, 2) is plate.wells[1 * 3 + 2]
+
+    def test_out_of_bounds_returns_none(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert plate.get_well(99, 99) is None
+
+
+class TestTotalWells:
+    def test_matches_well_count(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        assert plate.total_wells == 6
+
+
+class TestGetCoorInvalidPosition:
+    def test_out_of_bounds_raises(self) -> None:
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        with pytest.raises(ValueError, match="is invalid"):
+            plate.get_coor(99, 99)
+
+
+class TestNextWrapsWhenAlreadyPastTheEnd:
+    def test_cursor_manually_advanced_past_the_end_still_wraps(self) -> None:
+        """Covers the top-of-`next()` wrap reset, distinct from the
+
+        bottom-of-`next()` reset that ordinarily keeps `curr` from ever
+        reaching this state in normal use.
+        """
+        plate = PlateArray(_params(num_row=2, num_col=3))
+        plate.curr = len(plate.sequence)  # simulate an already-past-the-end cursor
+
+        first = plate.wells[plate.sequence[0]].coor
+
+        assert plate.next() == first
+
+
+# ==================== Plate base-class abstract-method bodies ====================
+
+
+class _AbstractBodyPlate(Plate):
+    """A concrete `Plate` whose `get_coor`/`get_dip_distance`/`next` delegate
+
+    to `super()` rather than overriding fully, so the base class's own (if
+    normally unreachable) `NotImplementedError` bodies can be exercised --
+    the same pattern `test_well.py` uses for `DipStrategy`. Subclasses `Plate`
+    directly (not `PlateArray`) so `super()` resolves to `Plate`'s own
+    methods rather than a concrete sibling implementation.
+    """
+
+    def _gen_wells(
+        self,
+        start_coor: Coordinate,
+        well_template: Well,
+        num_row: int,
+        num_col: int,
+        spacing_row: float,
+        spacing_col: float,
+    ) -> list[Well]:
+        del start_coor, num_row, num_col, spacing_row, spacing_col
+        return [well_template]
+
+    def get_coor(self, row: int, col: int) -> Coordinate:
+        return super().get_coor(row, col)  # pyright: ignore[reportAbstractUsage]
+
+    def get_dip_distance(self, vol: float | None) -> float:
+        return super().get_dip_distance(vol)  # pyright: ignore[reportAbstractUsage]
+
+    def next(self) -> Coordinate:
+        return super().next()  # pyright: ignore[reportAbstractUsage]
+
+
+class _GenWellsPassThrough(Plate):
+    """A minimal `Plate` whose `_gen_wells` delegates to `super()`, so the
+
+    abstract base body raises during construction itself.
+    """
+
+    def _gen_wells(
+        self,
+        start_coor: Coordinate,
+        well_template: Well,
+        num_row: int,
+        num_col: int,
+        spacing_row: float,
+        spacing_col: float,
+    ) -> list[Well]:
+        return super()._gen_wells(  # pyright: ignore[reportAbstractUsage]
+            start_coor, well_template, num_row, num_col, spacing_row, spacing_col
+        )
+
+    def get_coor(self, row: int, col: int) -> Coordinate:
+        raise NotImplementedError
+
+    def get_dip_distance(self, vol: float | None) -> float:
+        raise NotImplementedError
+
+    def next(self) -> Coordinate:
+        raise NotImplementedError
+
+
+class TestPlateAbstractMethodBodies:
+    def test_gen_wells_base_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match="_gen_wells"):
+            _GenWellsPassThrough(_params(num_row=1, num_col=1))
+
+    def test_get_coor_base_raises(self) -> None:
+        plate = _AbstractBodyPlate(_params(num_row=1, num_col=1))
+        with pytest.raises(NotImplementedError, match="get_coor"):
+            plate.get_coor(0, 0)
+
+    def test_get_dip_distance_base_raises(self) -> None:
+        plate = _AbstractBodyPlate(_params(num_row=1, num_col=1))
+        with pytest.raises(NotImplementedError, match="get_dip_distance"):
+            plate.get_dip_distance(0.0)
+
+    def test_next_base_raises(self) -> None:
+        plate = _AbstractBodyPlate(_params(num_row=1, num_col=1))
+        with pytest.raises(NotImplementedError, match="next"):
+            plate.next()
+
+
+# ==================== PlateFactory registration/creation edges ====================
+
+
+class _DummyPlate(PlateArray):
+    """A throwaway `Plate` subclass, registered/unregistered per-test below."""
+
+
+class TestPlateFactoryRegistration:
+    def test_duplicate_registration_raises(self) -> None:
+        PlateFactory.register("pytest_tmp_dup")(_DummyPlate)
+        assert PlateFactory._registry["pytest_tmp_dup"] is _DummyPlate
+
+        try:
+            with pytest.raises(ValueError, match="already registered"):
+                PlateFactory.register("pytest_tmp_dup")(_DummyPlate)
+        finally:
+            del PlateFactory._registry["pytest_tmp_dup"]
+
+
+class TestPlateFactoryCreateUnregistered:
+    def test_since_unregistered_type_raises(self) -> None:
+        """`PlateParams` normally guarantees a registered type; this covers
+
+        the factory's own defensive check for a type deregistered (or
+        mutated past validation) after the params were built.
+        """
+        params = _params(plate_type="array")
+        params.plate_type = "not_a_real_type"  # bypasses validate_plate_type
+
+        with pytest.raises(InvalidPlateTypeError):
+            PlateFactory.create(params)

--- a/tests/core/test_well.py
+++ b/tests/core/test_well.py
@@ -1,0 +1,248 @@
+"""Unit tests for ``core/well.py``: dip strategies, registry, and ``Well``."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from tricca_autopipette.core.coordinate import Coordinate
+from tricca_autopipette.core.well import (
+    CylinderDipStrategy,
+    DipStrategy,
+    SimpleDipStrategy,
+    StrategyRegistry,
+    StrategyType,
+    Well,
+    WellParams,
+)
+
+
+def _coord() -> Coordinate:
+    return Coordinate(x=10.0, y=20.0, z=5.0)
+
+
+class TestDipStrategyAbstractBody:
+    """`DipStrategy`'s two abstract methods carry a real (if unreachable in
+
+    normal use) `NotImplementedError` body -- covered here by a subclass
+    that delegates to `super()` rather than overriding fully.
+    """
+
+    class _PassThrough(DipStrategy):
+        def calculate_dip_distance(self, well: Well, volume: float) -> float:
+            return super().calculate_dip_distance(  # pyright: ignore[reportAbstractUsage]
+                well, volume
+            )
+
+        def validate_well_config(
+            self, well_diameter: float | None, dip_btm: float | None
+        ) -> None:
+            super().validate_well_config(  # pyright: ignore[reportAbstractUsage]
+                well_diameter, dip_btm
+            )
+
+    def test_calculate_dip_distance_base_raises(self) -> None:
+        strategy = self._PassThrough()
+        well = Well(coor=_coord(), dip_top=10.0)
+
+        with pytest.raises(NotImplementedError):
+            strategy.calculate_dip_distance(well, 100.0)
+
+    def test_validate_well_config_base_raises(self) -> None:
+        strategy = self._PassThrough()
+
+        with pytest.raises(NotImplementedError):
+            strategy.validate_well_config(8.0, 50.0)
+
+
+class TestSimpleDipStrategy:
+    def test_returns_dip_top_regardless_of_volume(self) -> None:
+        strategy = SimpleDipStrategy()
+        well = Well(coor=_coord(), dip_top=10.0)
+
+        # Exact JSON round-trip of a literal, not a computed value.
+        distance = strategy.calculate_dip_distance(well, 100.0)
+        assert distance == 10.0  # ruff:ignore[float-equality-comparison]
+
+    def test_validate_well_config_never_raises(self) -> None:
+        strategy = SimpleDipStrategy()
+        strategy.validate_well_config(None, None)  # must not raise
+        strategy.validate_well_config(8.0, 50.0)  # must not raise
+
+
+class TestCylinderDipStrategy:
+    def test_calculate_dip_distance_updates_dip_curr(self) -> None:
+        strategy = CylinderDipStrategy()
+        well = Well(
+            coor=_coord(),
+            dip_top=10.0,
+            dip_btm=50.0,
+            strategy_type=StrategyType.CYLINDER,
+            well_diameter=8.0,
+        )
+
+        distance = strategy.calculate_dip_distance(well, 100.0)
+
+        radius_m = 8.0 / (2 * strategy.MM_TO_M)
+        expected_change_mm = (
+            (100.0 * strategy.LITERS_TO_CUBIC_M) / (math.pi * radius_m**2)
+        ) * strategy.MM_TO_M
+        assert distance == pytest.approx(10.0 + expected_change_mm)
+        assert well.dip_curr == pytest.approx(distance)
+
+    def test_result_is_clamped_to_dip_btm(self) -> None:
+        strategy = CylinderDipStrategy()
+        well = Well(
+            coor=_coord(),
+            dip_top=45.0,
+            dip_btm=50.0,
+            strategy_type=StrategyType.CYLINDER,
+            well_diameter=8.0,
+        )
+
+        # A huge volume would overshoot dip_btm without clamping.
+        distance = strategy.calculate_dip_distance(well, 1_000_000.0)
+
+        assert distance == 50.0  # ruff:ignore[float-equality-comparison]
+
+    def test_missing_well_diameter_raises(self) -> None:
+        strategy = CylinderDipStrategy()
+        well = Well(coor=_coord(), dip_top=10.0)
+        well.dip_btm = 50.0  # bypass Well.__init__'s own validation
+
+        with pytest.raises(ValueError, match="well_diameter and dip_btm"):
+            strategy.calculate_dip_distance(well, 100.0)
+
+    def test_missing_dip_btm_raises(self) -> None:
+        strategy = CylinderDipStrategy()
+        well = Well(coor=_coord(), dip_top=10.0)
+        well.well_diameter = 8.0  # bypass Well.__init__'s own validation
+
+        with pytest.raises(ValueError, match="well_diameter and dip_btm"):
+            strategy.calculate_dip_distance(well, 100.0)
+
+    def test_validate_well_config_requires_diameter(self) -> None:
+        strategy = CylinderDipStrategy()
+        with pytest.raises(ValueError, match="requires well_diameter"):
+            strategy.validate_well_config(None, 50.0)
+
+    def test_validate_well_config_requires_dip_btm(self) -> None:
+        strategy = CylinderDipStrategy()
+        with pytest.raises(ValueError, match="requires dip_btm"):
+            strategy.validate_well_config(8.0, None)
+
+    def test_validate_well_config_passes_with_both(self) -> None:
+        strategy = CylinderDipStrategy()
+        strategy.validate_well_config(8.0, 50.0)  # must not raise
+
+
+class TestStrategyRegistry:
+    def test_get_strategy_returns_singleton_per_type(self) -> None:
+        assert isinstance(
+            StrategyRegistry.get_strategy(StrategyType.SIMPLE), SimpleDipStrategy
+        )
+        assert isinstance(
+            StrategyRegistry.get_strategy(StrategyType.CYLINDER), CylinderDipStrategy
+        )
+        # Same instance every time (registry, not a factory).
+        assert StrategyRegistry.get_strategy(
+            StrategyType.SIMPLE
+        ) is StrategyRegistry.get_strategy(StrategyType.SIMPLE)
+
+    def test_get_strategy_type_reverse_lookup_first_entry(self) -> None:
+        assert (
+            StrategyRegistry.get_strategy_type(SimpleDipStrategy())
+            == StrategyType.SIMPLE
+        )
+
+    def test_get_strategy_type_reverse_lookup_later_entry(self) -> None:
+        """Exercises the loop continuing past a non-matching first entry."""
+        assert (
+            StrategyRegistry.get_strategy_type(CylinderDipStrategy())
+            == StrategyType.CYLINDER
+        )
+
+    def test_get_strategy_type_unknown_strategy_raises(self) -> None:
+        class _NotRegistered(DipStrategy):
+            def calculate_dip_distance(self, well: Well, volume: float) -> float:
+                return 0.0
+
+            def validate_well_config(
+                self, well_diameter: float | None, dip_btm: float | None
+            ) -> None:
+                pass
+
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            StrategyRegistry.get_strategy_type(_NotRegistered())
+
+
+class TestWellParams:
+    def test_simple_strategy_needs_no_extra_params(self) -> None:
+        params = WellParams(coor=_coord(), dip_top=10.0)
+        assert params.strategy_type == StrategyType.SIMPLE
+
+    def test_cylinder_strategy_valid_with_both_params(self) -> None:
+        params = WellParams(
+            coor=_coord(),
+            dip_top=10.0,
+            dip_btm=50.0,
+            strategy_type=StrategyType.CYLINDER,
+            well_diameter=8.0,
+        )
+        assert params.well_diameter == 8.0  # ruff:ignore[float-equality-comparison]
+
+    def test_cylinder_strategy_missing_diameter_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="requires well_diameter"):
+            WellParams(
+                coor=_coord(),
+                dip_top=10.0,
+                dip_btm=50.0,
+                strategy_type=StrategyType.CYLINDER,
+            )
+
+    def test_cylinder_strategy_missing_dip_btm_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="requires dip_btm"):
+            WellParams(
+                coor=_coord(),
+                dip_top=10.0,
+                strategy_type=StrategyType.CYLINDER,
+                well_diameter=8.0,
+            )
+
+    def test_non_positive_dip_top_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WellParams(coor=_coord(), dip_top=0.0)
+
+
+class TestWellStrategyTypeProperty:
+    def test_reports_configured_strategy(self) -> None:
+        well = Well(
+            coor=_coord(),
+            dip_top=10.0,
+            dip_btm=50.0,
+            strategy_type=StrategyType.CYLINDER,
+            well_diameter=8.0,
+        )
+        assert well.strategy_type == StrategyType.CYLINDER
+
+    def test_defaults_to_simple(self) -> None:
+        well = Well(coor=_coord(), dip_top=10.0)
+        assert well.strategy_type == StrategyType.SIMPLE
+
+
+class TestWellConstructionValidation:
+    def test_cylinder_without_diameter_raises_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="requires well_diameter"):
+            Well(coor=_coord(), dip_top=10.0, strategy_type=StrategyType.CYLINDER)
+
+    def test_get_dip_distance_delegates_to_strategy(self) -> None:
+        well = Well(
+            coor=_coord(),
+            dip_top=10.0,
+            dip_btm=50.0,
+            strategy_type=StrategyType.CYLINDER,
+            well_diameter=8.0,
+        )
+        assert well.get_dip_distance(0.0) == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
Gap-fill test coverage for the `core/` modules flagged in #42 as trailing the rest of the module (81% core/-wide baseline). Brings every named module up to (or near) 100%, and `core/` overall to **98%**:

| Module | Before | After |
|---|---|---|
| `config_validation.py` | 0% | 100% |
| `json_config_manager.py` | 57% | 99% |
| `location_manager.py` | 79% | 98% |
| `coordinate.py` | 58% | 100% |
| `well.py` | 71% | 100% |
| `gcode_buffer.py` | 61% | 100% |
| `pipette_exceptions.py` | 77% | 100% |
| `pipette_models.py` | 87% | 100% |
| `plates.py` | 90% | 100% |

## Notable additions
- **`config_validation.py`**: new file, monkeypatches the module's `DIR_CONFIG_*`/`CONFIG_SYSTEM` constants into an isolated `tmp_path` tree.
- **`json_config_manager.py`**: `load_gantry`/`load_pipette`/`load_liquid` were entirely untested — now covered, plus the `extends` depth guard, ancestor-level non-string-`extends` check, `_load_default_*`'s missing-directory/malformed-file branches, and more. Adds `write_gantry_config`/`write_pipette_config`/`write_liquid_config` fixtures sharing one `_scratch_writer` body with the pre-existing `write_system_config`.
- **`location_manager.py`**: `load_spec`, `load_group(replace=True)`, `plate_file` references (via the real `config/plates/96_well_standard.json` template), tips-block validation, `get_location_info`, and more. A few `hasattr`-guarded branches in `save_to_json` are left uncovered as structurally unreachable through the real `Plate` hierarchy (documented inline).
- **`coordinate.py`**, **`well.py`**, **`gcode_buffer.py`**, **`pipette_exceptions.py`**, **`pipette_models.py`**: new files, straightforward full-method coverage.
- **`plates.py`**: `Plate`'s abstract-method bodies (`_gen_wells`/`get_coor`/`get_dip_distance`/`next`) covered via a pass-through subclass — the same pattern `test_well.py` uses for `DipStrategy`.

No new test infrastructure: everything follows the existing `tests/core/` conventions (real objects built from real default configs where practical, scratch files for the two managers with no constructor-level injection point, monkeypatched `DIR_CONFIG_*` constants only where a missing-directory/malformed-file case needs one).

Full suite: 781 passed.

Closes #42.