### PR TITLE
feat: instrument movement/RPC logging (#52)

### DIFF
--- a/src/tricca_autopipette/core/autopipette.py
+++ b/src/tricca_autopipette/core/autopipette.py
@@ -183,6 +183,50 @@ class AutoPipette:
             pre_air_gap_ul=merged["pre_air_gap_ul"],
             post_air_gap_ul=merged["post_air_gap_ul"],
         )
+        self._technique_provenance = self._compute_technique_provenance()
+
+    def _compute_technique_provenance(self) -> dict[str, str]:
+        """Tag each merged technique default with where it came from.
+
+        Mirrors ``JsonConfigManager.get_merged_syringe_params``'s own
+        liquid-overrides-pipette merge (``is not None`` wins), but records
+        *which* tier supplied the value instead of the value itself, for
+        ``resolve_technique``/``note_action`` to report alongside the
+        resolved numbers.
+
+        Returns:
+            Mapping of ``pre_air_gap_ul``/``post_air_gap_ul``/
+            ``prewet_cycles``/``prewet_vol_ul`` to either
+            ``"liquid:<name>"`` or ``"pipette default"``.
+        """
+        liquid = self.system_config.liquids[self.active_liquid]
+        fields = ("pre_air_gap_ul", "post_air_gap_ul", "prewet_cycles", "prewet_vol_ul")
+        return {
+            field: (
+                f"liquid:{self.active_liquid}"
+                if getattr(liquid, field) is not None
+                else "pipette default"
+            )
+            for field in fields
+        }
+
+    def note_action(self, message: str) -> None:
+        """Record one logical action via both the run log and the G-code.
+
+        Logs ``message`` at INFO and, using the exact same string, adds a
+        matching G-code comment immediately ahead of the action's commands
+        -- the run log and the G-code file can therefore never end up
+        describing an action differently. Also used directly by
+        ``AutoPipetteService`` (``daemon/service.py``) for the handful of
+        actions -- plain moves, individual-motor homing -- that don't
+        already flow through one of this class's own action methods.
+
+        Args:
+            message: Human-readable description of the action, e.g.
+                ``"Aspirating 50.0μL from 'plate_a'"``.
+        """
+        self.logger.info(message)
+        self.gcode_buffers.add_comment(message)
 
     def switch_liquid(self, liquid_name: str) -> None:
         """Switch to a different liquid profile.
@@ -217,7 +261,7 @@ class AutoPipette:
         self._update_syringe_params()
         self._init_volume_converter()  # Reload with new calibration
 
-        self.logger.info(f"Switched to liquid: {liquid_name}")
+        self.note_action(f"Switched to liquid: {liquid_name}")
 
     def _initialize_from_config(self) -> None:
         """Initialize pipette from loaded configuration.
@@ -320,6 +364,10 @@ class AutoPipette:
         self.home_axis()
         self.home_pipette_motors()
         self.state.homed = True
+        self.note_action(
+            "Pipette initialized: absolute coordinates, speed configured, "
+            "XYZ and pipette motors homed"
+        )
 
     def init_speed(self) -> None:
         """Configure speed and acceleration parameters.
@@ -354,8 +402,10 @@ class AutoPipette:
         mode_str = mode.value if isinstance(mode, CoordinateSystem) else mode.lower()
 
         if mode_str == CoordinateSystem.ABSOLUTE.value:
+            self.logger.debug("Coordinate system: absolute")
             self.gcode_buffers.add(f"{GCodeCommand.ABSOLUTE_MODE}\n")
         elif mode_str == CoordinateSystem.RELATIVE.value:
+            self.logger.debug("Coordinate system: relative")
             self.gcode_buffers.add(f"{GCodeCommand.RELATIVE_MODE}\n")
         else:
             raise ValueError(
@@ -375,6 +425,7 @@ class AutoPipette:
         Example:
             >>> pipette.set_speed_factor(150)  # doctest: +SKIP
         """
+        self.logger.debug("Speed factor: %s%%", factor)
         self.gcode_buffers.add(f"{GCodeCommand.SPEED_FACTOR} S{factor}\n")
 
     def set_max_velocity(self, velocity: float) -> None:
@@ -386,6 +437,7 @@ class AutoPipette:
         Example:
             >>> pipette.set_max_velocity(5000)  # doctest: +SKIP
         """
+        self.logger.debug("Max velocity: %s mm/s", velocity)
         self.gcode_buffers.add(f"SET_VELOCITY_LIMIT VELOCITY={velocity}\n")
 
     def set_max_accel(self, accel: float) -> None:
@@ -397,6 +449,7 @@ class AutoPipette:
         Example:
             >>> pipette.set_max_accel(3000)  # doctest: +SKIP
         """
+        self.logger.debug("Max acceleration: %s mm/s²", accel)
         self.gcode_buffers.add(f"SET_VELOCITY_LIMIT ACCEL={accel}\n")
 
     def home_axis(self) -> None:
@@ -405,27 +458,33 @@ class AutoPipette:
         Example:
             >>> pipette.home_axis()  # doctest: +SKIP
         """
+        self.note_action("Homing all axes (X, Y, Z)")
         self.gcode_buffers.add(f"{GCodeCommand.HOME_ALL}\n")
 
     def home_x(self) -> None:
         """Home X axis only."""
+        self.note_action("Homing X axis")
         self.gcode_buffers.add(f"{GCodeCommand.HOME_X}\n")
 
     def home_y(self) -> None:
         """Home Y axis only."""
+        self.note_action("Homing Y axis")
         self.gcode_buffers.add(f"{GCodeCommand.HOME_Y}\n")
 
     def home_z(self) -> None:
         """Home Z axis only."""
+        self.note_action("Homing Z axis")
         self.gcode_buffers.add(f"{GCodeCommand.HOME_Z}\n")
 
     def home_pipette_motors(self) -> None:
         """Home all pipette-specific motors."""
+        self.note_action("Homing pipette motors (servo + stepper)")
         self.home_servo()
         self.home_pipette_stepper()
 
     def home_servo(self) -> None:
         """Retract the tip ejection servo to home position."""
+        self.note_action("Homing servo (retract to home position)")
         self.set_servo_angle(self.pipette_model.servo.angle_retract)
         self.gcode_wait(self.pipette_model.servo.wait_ms)
 
@@ -455,6 +514,13 @@ class AutoPipette:
         distance *= self.syringe.motor_orientation
         opposite_distance = distance * -1
 
+        self.logger.debug(
+            "MANUAL_STEPPER %s homing: distance=%s speed=%s accel=%s",
+            stepper,
+            distance,
+            speed,
+            accel,
+        )
         self.gcode_buffers.add(
             f"MANUAL_STEPPER STEPPER={stepper} SET_POSITION=0 "
             f"MOVE={distance} SPEED={speed} ACCEL={accel} "
@@ -473,6 +539,14 @@ class AutoPipette:
         """
         speed_xy = self.gantry.speed_xy
         speed_z = self.gantry.speed_z
+        self.logger.debug(
+            "G-code move: X=%s Y=%s Z=%s (speed_xy=%s speed_z=%s)",
+            coordinate.x,
+            coordinate.y,
+            coordinate.z,
+            speed_xy,
+            speed_z,
+        )
         self.gcode_buffers.add(
             f"{GCodeCommand.LINEAR_MOVE} X{coordinate.x} Y{coordinate.y} F{speed_xy}\n"
         )
@@ -483,16 +557,19 @@ class AutoPipette:
     def move_to_x(self, coordinate: Coordinate) -> None:
         """Move only in X direction."""
         speed = self.gantry.speed_xy
+        self.logger.debug("G-code move: X=%s (speed=%s)", coordinate.x, speed)
         self.gcode_buffers.add(f"{GCodeCommand.LINEAR_MOVE} X{coordinate.x} F{speed}\n")
 
     def move_to_y(self, coordinate: Coordinate) -> None:
         """Move only in Y direction."""
         speed = self.gantry.speed_xy
+        self.logger.debug("G-code move: Y=%s (speed=%s)", coordinate.y, speed)
         self.gcode_buffers.add(f"{GCodeCommand.LINEAR_MOVE} Y{coordinate.y} F{speed}\n")
 
     def move_to_z(self, coordinate: Coordinate) -> None:
         """Move only in Z direction."""
         speed = self.gantry.speed_z
+        self.logger.debug("G-code move: Z=%s (speed=%s)", coordinate.z, speed)
         self.gcode_buffers.add(f"{GCodeCommand.LINEAR_MOVE} Z{coordinate.z} F{speed}\n")
 
     def set_servo_angle(self, angle: float) -> None:
@@ -502,6 +579,7 @@ class AutoPipette:
             angle: Target angle in degrees.
         """
         servo = self.pipette_model.servo.name
+        self.logger.debug("SET_SERVO %s: angle=%s", servo, angle)
         self.gcode_buffers.add(f"SET_SERVO SERVO={servo} ANGLE={angle}\n")
 
     def move_pipette_stepper(
@@ -526,6 +604,13 @@ class AutoPipette:
         if accel is None:
             accel = self.syringe.accel_move
 
+        self.logger.debug(
+            "MANUAL_STEPPER %s move: distance=%s speed=%s accel=%s",
+            stepper,
+            distance,
+            speed,
+            accel,
+        )
         self.gcode_buffers.add(
             f"MANUAL_STEPPER STEPPER={stepper} SET_POSITION=0 "
             f"SPEED={speed} MOVE={distance} ACCEL={accel} "
@@ -539,6 +624,7 @@ class AutoPipette:
         Args:
             milliseconds: Duration to wait in milliseconds.
         """
+        self.logger.debug("Dwell: %s ms", milliseconds)
         self.gcode_buffers.add(f"{GCodeCommand.DWELL} P{milliseconds}\n")
 
     def gcode_print(self, msg: str) -> None:
@@ -547,6 +633,7 @@ class AutoPipette:
         Args:
             msg: Message string to display.
         """
+        self.note_action(f"Displaying message: {msg}")
         self.gcode_buffers.add(f"{GCodeCommand.DISPLAY_MESSAGE} {msg}\n")
 
     def get_gcode(self) -> list[str]:
@@ -583,7 +670,10 @@ class AutoPipette:
 
         # The supplying box comes back with the coordinate: boxes may sit at
         # different heights, so the dip distance must come from *that* box.
-        _name, box, loc_tip = self.location_manager.tipbox_manager.next_tip()
+        name, box, loc_tip = self.location_manager.tipbox_manager.next_tip()
+        self.note_action(
+            f"Picking up tip from '{name}' at (X:{loc_tip.x:.2f}, Y:{loc_tip.y:.2f})"
+        )
         self.move_to(loc_tip)
         self.dip_z_down(loc_tip, box.get_dip_distance(vol=None))
         self.dip_z_return(loc_tip)
@@ -591,6 +681,7 @@ class AutoPipette:
 
     def eject_tip(self) -> None:
         """Eject the current pipette tip."""
+        self.note_action("Ejecting tip")
         angle_retract = self.pipette_model.servo.angle_retract
         angle_eject = self.pipette_model.servo.angle_eject
         wait_eject = self.pipette_model.servo.wait_ms
@@ -612,6 +703,7 @@ class AutoPipette:
         if self.location_manager.waste_container is None:
             raise NoWasteContainerError()
 
+        self.note_action("Disposing tip to waste container")
         curr_coor = self.location_manager.waste_container.next()
         self.move_to(curr_coor)
         self.dip_z_down(
@@ -627,6 +719,7 @@ class AutoPipette:
             curr_coor: Current XY position.
             distance: Distance to move down in Z axis.
         """
+        self.logger.debug("Dipping down to Z=%s", distance)
         coor_dip = Coordinate(x=curr_coor.x, y=curr_coor.y, z=distance)
         self.move_to_z(coor_dip)
         self.gcode_wait(100)  # Default wait
@@ -637,6 +730,7 @@ class AutoPipette:
         Args:
             curr_coor: Original coordinate to return to.
         """
+        self.logger.debug("Returning to Z=%s", curr_coor.z)
         self.move_to_z(curr_coor)
         self.gcode_wait(100)  # Default wait
 
@@ -670,6 +764,12 @@ class AutoPipette:
         steps = self.volume_converter.vol_to_steps(vol_ul)
         steps *= direction
         steps *= self.syringe.motor_orientation
+        self.logger.debug(
+            "Syringe %s: %s μL (%s mm plunger travel)",
+            "aspiration" if direction == FluidDisplacement.aspiration else "dispense",
+            vol_ul,
+            steps,
+        )
         self.move_pipette_stepper(steps, stepper, speed, accel)
 
     def clear_syringe(
@@ -696,6 +796,13 @@ class AutoPipette:
         distance *= FluidDisplacement.dispense
         distance *= self.syringe.motor_orientation
 
+        self.logger.debug(
+            "MANUAL_STEPPER %s clear: distance=%s speed=%s accel=%s",
+            stepper,
+            distance,
+            speed,
+            accel,
+        )
         self.gcode_buffers.add(
             f"MANUAL_STEPPER STEPPER={stepper} SET_POSITION=0 "
             f"MOVE={distance} SPEED={speed} ACCEL={accel} "
@@ -710,6 +817,9 @@ class AutoPipette:
             curr_coor: Current coordinate position.
             dip_distance: Z-axis position where shaking occurs.
         """
+        self.logger.debug(
+            "Wiggling at Z=%s to dislodge residual droplets", dip_distance
+        )
         base_coor = Coordinate(x=curr_coor.x, y=curr_coor.y, z=dip_distance)
         shake_offset = PhysicalConstants.WIGGLE_OFFSET_MM
 
@@ -768,6 +878,50 @@ class AutoPipette:
             else post_air_gap_ul,
             self.syringe.prewet_cycles if prewet_cycles is None else prewet_cycles,
             self.syringe.prewet_vol_ul if prewet_vol_ul is None else prewet_vol_ul,
+        )
+
+    def _technique_sources(
+        self,
+        pre_air_gap_ul: float | None,
+        post_air_gap_ul: float | None,
+        prewet_cycles: int | None,
+        prewet_vol_ul: float | None,
+    ) -> tuple[str, str, str, str]:
+        """Tag each technique argument with where its resolved value came from.
+
+        Mirrors ``resolve_technique``'s own explicit-argument > liquid-profile
+        > pipette-default precedence, but reports *which* tier won instead of
+        the value. Must be called with the same pre-resolution arguments
+        (before ``resolve_technique`` overwrites them with resolved values),
+        since a caller that reassigns its locals in place loses the
+        "was this explicit" information otherwise.
+
+        Args:
+            pre_air_gap_ul: Requested pre-aspirate air gap, or None.
+            post_air_gap_ul: Requested post-aspirate air gap, or None.
+            prewet_cycles: Requested prewet cycle count, or None.
+            prewet_vol_ul: Requested prewet volume, or None.
+
+        Returns:
+            Source tags for ``(pre_air_gap_ul, post_air_gap_ul,
+            prewet_cycles, prewet_vol_ul)`` -- each either
+            ``"explicit flag"`` or the matching entry from
+            ``self._technique_provenance``.
+        """
+        provenance = self._technique_provenance
+        return (
+            "explicit flag"
+            if pre_air_gap_ul is not None
+            else provenance["pre_air_gap_ul"],
+            "explicit flag"
+            if post_air_gap_ul is not None
+            else provenance["post_air_gap_ul"],
+            "explicit flag"
+            if prewet_cycles is not None
+            else provenance["prewet_cycles"],
+            "explicit flag"
+            if prewet_vol_ul is not None
+            else provenance["prewet_vol_ul"],
         )
 
     def usable_capacity_ul(self) -> float:
@@ -879,6 +1033,9 @@ class AutoPipette:
                 f"Aspiration requires a plate with dipping strategy."
             )
 
+        sources = self._technique_sources(
+            pre_air_gap_ul, post_air_gap_ul, prewet_cycles, prewet_vol_ul
+        )
         pre_air_gap_ul, post_air_gap_ul, prewet_cycles, prewet_vol_ul = (
             self.resolve_technique(
                 pre_air_gap_ul, post_air_gap_ul, prewet_cycles, prewet_vol_ul
@@ -891,6 +1048,18 @@ class AutoPipette:
         # tip, so it gets the headroom left over from that -- not the whole
         # syringe.
         prewet_vol_ul = min(prewet_vol_ul, self.usable_capacity_ul() - pre_air_gap_ul)
+
+        well = (
+            source
+            if src_row is None or src_col is None
+            else f"{source}[{src_row},{src_col}]"
+        )
+        self.note_action(
+            f"Aspirating {volume:g}μL from '{well}' "
+            f"(pre_air_gap={pre_air_gap_ul:g}μL[{sources[0]}], "
+            f"post_air_gap={post_air_gap_ul:g}μL[{sources[1]}], "
+            f"prewet={prewet_cycles}x{prewet_vol_ul:g}μL[{sources[2]}/{sources[3]}])"
+        )
 
         self.move_to(coor_source)
         self.home_pipette_stepper()
@@ -955,6 +1124,14 @@ class AutoPipette:
                 f"Destination '{dest}' is a coordinate, not a plate. "
                 f"Dispensing requires a plate with dipping strategy."
             )
+
+        well = (
+            dest
+            if dest_row is None or dest_col is None
+            else f"{dest}[{dest_row},{dest_col}]"
+        )
+        vol_desc = f"{volume:g}μL" if volume else "remaining volume"
+        self.note_action(f"Dispensing {vol_desc} to '{well}'")
 
         self.move_to(coor_dest)
         self.dip_z_down(coor_dest, loc_dest.get_dip_distance(volume))
@@ -1088,6 +1265,11 @@ class AutoPipette:
         # Add remainder if significant
         if remainder > PhysicalConstants.VOLUME_TOLERANCE_UL:
             transfer_volumes.append(remainder)
+
+        self.note_action(
+            f"Transferring {vol_ul:g}μL from '{source}' to '{dest}' "
+            f"({len(transfer_volumes)} chunk(s))"
+        )
 
         # Execute transfer sequence
         for pip_vol in transfer_volumes:
@@ -1285,6 +1467,11 @@ class AutoPipette:
             _ = tipbox_name
             self.next_tip()  # TODO: Pass in preferred tipbox
 
+        destinations = ", ".join(f"{s.dest}:{s.vol_ul:g}μL" for s in splits)
+        self.note_action(
+            f"Aspirating {vol_ul:g}μL from '{source}' for {len(splits)} split(s) "
+            f"({destinations})"
+        )
         self.aspirate_volume(
             vol_ul,
             source,
@@ -1341,6 +1528,7 @@ class AutoPipette:
         if waste is None:
             raise NoWasteContainerError()
 
+        self.note_action("Emptying leftover tip contents to waste container")
         curr_coor = waste.next()
         self.move_to(curr_coor)
         self.dip_z_down(curr_coor, waste.get_dip_distance(vol=None))

--- a/src/tricca_autopipette/core/gcode_buffer.py
+++ b/src/tricca_autopipette/core/gcode_buffer.py
@@ -44,6 +44,31 @@ class GCodeBuffer:
         """
         self._commands.append(command)
 
+    def add_comment(self, message: str) -> None:
+        r"""Add a single-line G-code comment to the command buffer.
+
+        Unlike ``add_header``, this goes in the command buffer itself so it
+        appears inline, immediately before the G-code it describes, rather
+        than in the one-off configuration header. Intended for one comment
+        per logical action (e.g. one aspirate, one dispense), not per raw
+        G-code line -- see ``AutoPipette.note_action``, which calls this
+        with the exact same message it logs at INFO, so the G-code file and
+        the run log can never describe an action differently.
+
+        Args:
+            message: Human-readable description of the action. Must not
+                itself contain a newline.
+
+        Example:
+            >>> buffer = GCodeBuffer()
+            >>> buffer.add_comment("Aspirating 50.0μL from 'plate_a'")
+            >>> buffer.add("G1 X10 Y10 F5000\n")
+            >>> commands = buffer.get_commands()
+            >>> # commands = ["; Aspirating 50.0μL from 'plate_a'\n",
+            >>> #             "G1 X10 Y10 F5000\n"]
+        """
+        self.add(f"; {message}\n")
+
     def add_header(self, line: str) -> None:
         r"""Add a line to the configuration header.
 

--- a/src/tricca_autopipette/daemon/control_server.py
+++ b/src/tricca_autopipette/daemon/control_server.py
@@ -200,6 +200,11 @@ class ControlServer:
         params: dict[str, Any] = request.get("params") or {}
         request_id = request.get("id")
 
+        # The control plane has no authentication (loopback-only trust, see
+        # CLAUDE.md) -- this is the only audit trail available for who did
+        # what, so every RPC is logged before it runs, not just failures.
+        logger.info("Control-plane RPC: %s %r", method, params)
+
         try:
             result = await self._call(method, params)
             await ws.send_json({"id": request_id, "result": result})

--- a/src/tricca_autopipette/daemon/main.py
+++ b/src/tricca_autopipette/daemon/main.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import signal
 import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from tricca_autopipette.core.config_validation import validate_config_files
@@ -29,6 +30,13 @@ from tricca_autopipette.daemon.service import AutoPipetteService
 DEFAULT_LOG_FILE = "tapd.log"
 LOG_FORMAT = "%(asctime)s [%(module)s] %(levelname)s: %(message)s"
 DEFAULT_LOG_LEVEL = logging.INFO
+# Issue #52 meaningfully increases log volume (an INFO line per movement/
+# pipetting action plus every control-plane RPC) -- a plain FileHandler
+# would grow unbounded on a long-running daemon, so rotate instead. 10 MiB
+# x 5 backups is a size cap, not a tuned figure; revisit if real-world
+# volume warrants it.
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024
+DEFAULT_LOG_BACKUP_COUNT = 5
 
 
 def setup_logging(
@@ -44,11 +52,20 @@ def setup_logging(
         level=level,
         format=LOG_FORMAT,
         handlers=[
-            logging.FileHandler(log_file),
+            RotatingFileHandler(
+                log_file,
+                maxBytes=DEFAULT_LOG_MAX_BYTES,
+                backupCount=DEFAULT_LOG_BACKUP_COUNT,
+            ),
             logging.StreamHandler(sys.stdout),
         ],
     )
-    logging.info("Logging initialized: %s", log_file)
+    logging.info(
+        "Logging initialized: %s (rotating, max %d bytes x %d backups)",
+        log_file,
+        DEFAULT_LOG_MAX_BYTES,
+        DEFAULT_LOG_BACKUP_COUNT,
+    )
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/src/tricca_autopipette/daemon/service.py
+++ b/src/tricca_autopipette/daemon/service.py
@@ -661,6 +661,12 @@ class AutoPipetteService:
         """  # ruff: ignore[docstring-extraneous-exception]
         autopipette = self._autopipette
         coor = Coordinate(x=args.x, y=args.y, z=args.z)
+        # note_action here (rather than inside move_to itself) because
+        # move_to is also used internally as a raw positioning primitive by
+        # aspirate/dispense/tip-handling, which already log their own,
+        # higher-level action -- logging every move_to call would duplicate
+        # or drown those out.
+        autopipette.note_action(f"Moving to X:{args.x} Y:{args.y} Z:{args.z}")
         autopipette.move_to(coor)
         self.output_gcode(autopipette.get_gcode())
         return CommandResult(
@@ -687,6 +693,10 @@ class AutoPipetteService:
         autopipette = self._autopipette
         coor = autopipette.location_manager.get_coordinate(
             args.name_loc, args.row, args.col
+        )
+        autopipette.note_action(
+            f"Moving to '{args.name_loc}' "
+            f"(X:{coor.x:.2f} Y:{coor.y:.2f} Z:{coor.z:.2f})"
         )
         autopipette.move_to(coor)
         self.output_gcode(autopipette.get_gcode())
@@ -734,11 +744,6 @@ class AutoPipetteService:
         autopipette = self._autopipette
         coor = Coordinate(x=args.x, y=args.y, z=args.z)
 
-        autopipette.set_coor_sys(CoordinateSystem.RELATIVE)
-        autopipette.move_to(coor)
-        autopipette.set_coor_sys(CoordinateSystem.ABSOLUTE)
-        self.output_gcode(autopipette.get_gcode())
-
         parts: list[str] = []
         if args.x != 0:
             parts.append(f"X{args.x:+.2f}")
@@ -746,6 +751,13 @@ class AutoPipetteService:
             parts.append(f"Y{args.y:+.2f}")
         if args.z != 0:
             parts.append(f"Z{args.z:+.2f}")
+        autopipette.note_action(f"Moving relative: {' '.join(parts)}")
+
+        autopipette.set_coor_sys(CoordinateSystem.RELATIVE)
+        autopipette.move_to(coor)
+        autopipette.set_coor_sys(CoordinateSystem.ABSOLUTE)
+        self.output_gcode(autopipette.get_gcode())
+
         return CommandResult(ok=True, message=f"Moving relative: {' '.join(parts)}")
 
     # ==================== Pipette commands ====================

--- a/tests/core/test_autopipette.py
+++ b/tests/core/test_autopipette.py
@@ -80,7 +80,9 @@ class TestGCodeBuffer:
         autopipette.gcode_print("hello")
 
         first = autopipette.get_gcode()
-        assert len(first) == 2
+        # gcode_wait emits one dwell line; gcode_print emits an action
+        # comment (see AutoPipette.note_action) plus its own display line.
+        assert len(first) == 3
 
         # get_gcode() is destructive -- a second call sees nothing new.
         assert autopipette.get_gcode() == []

--- a/tests/daemon/test_main.py
+++ b/tests/daemon/test_main.py
@@ -25,6 +25,7 @@ import io
 import logging
 import os
 import signal
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, cast
 
@@ -159,8 +160,12 @@ class TestSetupLogging:
         handlers = cast("list[logging.Handler]", captured["handlers"])
         assert len(handlers) == 2
         file_handler, stream_handler = handlers
-        assert isinstance(file_handler, logging.FileHandler)
+        # Rotating, not a plain FileHandler -- issue #52 meaningfully
+        # increases log volume, so unbounded growth needs a cap.
+        assert isinstance(file_handler, RotatingFileHandler)
         assert file_handler.baseFilename == str(log_file)
+        assert file_handler.maxBytes == main_module.DEFAULT_LOG_MAX_BYTES
+        assert file_handler.backupCount == main_module.DEFAULT_LOG_BACKUP_COUNT
         assert (
             cast("logging.StreamHandler[Any]", stream_handler).stream is sentinel_stdout
         )


### PR DESCRIPTION
## Summary

Closes #52. Logging across the movement/RPC path was sparse, not just
inconsistent: `core/autopipette.py` (1310 lines, the whole
movement/G-code-emission engine) had 4 logger calls total, and
`daemon/service.py` (the RPC dispatch hub both `tap` and the kiosk
route every command through) had 2.

- **`AutoPipette.note_action`** (`core/autopipette.py`): logs one
  message at INFO and adds the *exact same string* as a G-code comment
  immediately ahead of the action's commands, so the run log and the
  G-code file can never end up describing an action differently.
  Backed by a new `GCodeBuffer.add_comment`.
- **Movement/pipetting actions → INFO**: homing (per-axis/servo/
  stepper/all), `init_pipette`, `switch_liquid`, tip pickup/eject/
  dispose/empty-to-waste, `aspirate_volume`/`dispense_volume`,
  `pipette`/`pipette_splits`, `gcode_print`, and `move`/`move_loc`/
  `move_rel` (via `daemon/service.py`, since `move_to` itself stays a
  raw internal primitive reused by aspirate/dispense/tip-handling and
  logging every call there would drown out their own action logs).
- **Raw G-code/mechanism → DEBUG**: `move_to*`, `set_servo_angle`,
  `home_pipette_stepper`, `move_pipette_stepper`, `clear_syringe`,
  `set_coor_sys`, speed/accel setters, `gcode_wait`, `dip_z_down`/
  `dip_z_return`, `operate_syringe`, `wiggle`.
- **Variable provenance**: `aspirate_volume`'s resolved technique
  values (`pre_air_gap_ul`, `post_air_gap_ul`, `prewet_cycles`,
  `prewet_vol_ul`) are tagged with where they came from — an explicit
  flag, the active liquid profile, or the pipette default — folded
  into the same INFO action line rather than logged separately.
- **Every control-plane RPC logged at INFO** in
  `ControlServer._dispatch` (method + params) before it runs — the
  only audit trail available given the control plane is loopback-only/
  unauthenticated.
- **`setup_logging`** (`daemon/main.py`): `logging.FileHandler` →
  `RotatingFileHandler` (10 MiB × 5 backups), since this issue
  meaningfully increases log volume.

Out of scope (split to #53, `needs-triage`): tagging which client
(`tap` vs. kiosk) sent an RPC — needs a control-plane envelope change,
not a logging change.

## Verification

- `pytest` — 1003 passed
- `pytest --doctest-modules` — 1148 passed, 20 skipped
- `ruff check .` — clean on `src/`; the 34 pre-existing `tests/**`
  findings from PR #55 are unchanged (confirmed against `main`)
- `ruff format --check .` — clean
- `pyright` — 0 errors
- `sphinx-build -W docs docs/_build/html` — clean
- Manual smoke test confirms the log/G-code-comment output reads as
  intended, e.g.:
  ```
  Picking up tip from 'tipbox' at (X:10.00, Y:10.00)
  Aspirating 30μL from 'plate_a[0,0]' (pre_air_gap=0μL[pipette default], post_air_gap=0μL[pipette default], prewet=0x10μL[pipette default/pipette default])
  Dispensing 30μL to 'plate_a[0,1]'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw9TRe7PFMpjfr7zUoeumh