### PR TITLE
feat(daemon): tag control-plane RPCs with which client sent them

### DIFF
--- a/src/autopipette_kiosk/main.py
+++ b/src/autopipette_kiosk/main.py
@@ -117,6 +117,17 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     )
     if not connected:
         logger.error("Failed to connect to tapd control plane at %s", TAPD_CONTROL_URI)
+    else:
+        # One-time identity so the daemon's RPC log can attribute
+        # subsequent calls on this connection to "kiosk" (issue #53) -- an
+        # audit-trail label, not access control, so a failure here is
+        # logged rather than treated as fatal to startup.
+        try:
+            await asyncio.to_thread(
+                client.send_jsonrpc, _control_requests.identify("kiosk")
+            )
+        except RuntimeError:
+            logger.warning("Failed to identify this connection to tapd.")
     _control_client = client
 
     try:

--- a/src/tricca_autopipette/cli/remote_shell.py
+++ b/src/tricca_autopipette/cli/remote_shell.py
@@ -117,6 +117,14 @@ class RemoteTapShell(Cmd):
             )
         else:
             self.poutput("Connected.")
+            # One-time identity so the daemon's RPC log can attribute
+            # subsequent calls on this connection to "tap" (issue #53) --
+            # an audit-trail label, not access control, so a failure here
+            # is logged rather than treated as fatal to the shell.
+            try:
+                self.client.send_jsonrpc(self.requests.identify("tap"))
+            except RuntimeError:
+                logger.warning("Failed to identify this connection to tapd.")
 
     def postloop(self) -> None:
         """Disconnect from the daemon's control plane on exit."""

--- a/src/tricca_autopipette/daemon/control_requests.py
+++ b/src/tricca_autopipette/daemon/control_requests.py
@@ -505,6 +505,23 @@ class ControlRequests:
         """
         return self.gen_request("daemon.ping")
 
+    def identify(self, client_type: str) -> dict[str, Any]:
+        """Build a one-time request identifying this connection's client type.
+
+        Both ``RemoteTapShell`` and the kiosk send this once, right after
+        connecting, hardcoded to their own fixed string ("tap"/"kiosk") --
+        see issue #53. This is an audit-trail label for the RPC log, not
+        access control: a connection that never identifies itself is still
+        served, just logged as "unknown".
+
+        Args:
+            client_type: Fixed client-type string, e.g. "tap" or "kiosk".
+
+        Returns:
+            Request to identify this connection.
+        """
+        return self.gen_request("daemon.identify", {"client_type": client_type})
+
     def run_stop(self) -> dict[str, Any]:
         """Build a request to send an emergency stop.
 

--- a/src/tricca_autopipette/daemon/control_server.py
+++ b/src/tricca_autopipette/daemon/control_server.py
@@ -91,7 +91,11 @@ class ControlServer:
         self.service = service
         self._host = host
         self._port = port
-        self._clients: set[web.WebSocketResponse] = set()
+        # Maps each connected client to the type it identified itself as
+        # via `daemon.identify` ("tap"/"kiosk"), or "unknown" for a
+        # connection that hasn't (yet) sent one -- an audit-trail label for
+        # the RPC log, not access control (see issue #53).
+        self._clients: dict[web.WebSocketResponse, str] = {}
         self._app = web.Application()
         self._app.router.add_get("/control", self._handle_control)
         self._runner: web.AppRunner | None = None
@@ -158,7 +162,7 @@ class ControlServer:
             except ConnectionResetError:
                 stale.append(ws)
         for ws in stale:
-            self._clients.discard(ws)
+            self._clients.pop(ws, None)
 
     async def _handle_control(self, request: web.Request) -> web.WebSocketResponse:
         """Handle one control-plane client connection for its lifetime.
@@ -171,7 +175,7 @@ class ControlServer:
         """
         ws = web.WebSocketResponse()
         await ws.prepare(request)
-        self._clients.add(ws)
+        self._clients[ws] = "unknown"
         try:
             async for msg in ws:
                 if msg.type == WSMsgType.TEXT:
@@ -179,7 +183,7 @@ class ControlServer:
                 elif msg.type == WSMsgType.ERROR:
                     logger.warning("Control websocket error: %s", ws.exception())
         finally:
-            self._clients.discard(ws)
+            self._clients.pop(ws, None)
         return ws
 
     async def _dispatch(self, ws: web.WebSocketResponse, raw: str) -> None:
@@ -203,10 +207,15 @@ class ControlServer:
         # The control plane has no authentication (loopback-only trust, see
         # CLAUDE.md) -- this is the only audit trail available for who did
         # what, so every RPC is logged before it runs, not just failures.
-        logger.info("Control-plane RPC: %s %r", method, params)
+        # Client type comes from a prior `daemon.identify` call on this same
+        # connection (see issue #53); a connection that never identified
+        # itself just logs as "unknown" -- this is an audit label, not
+        # access control, so nothing is rejected for omitting it.
+        client_type = self._clients.get(ws, "unknown")
+        logger.info("Control-plane RPC [%s]: %s %r", client_type, method, params)
 
         try:
-            result = await self._call(method, params)
+            result = await self._call(method, params, ws)
             await ws.send_json({"id": request_id, "result": result})
         except Exception as exc:
             logger.exception("Error dispatching control-plane method '%s'", method)
@@ -215,12 +224,22 @@ class ControlServer:
                 "error": {"type": type(exc).__name__, "message": str(exc)},
             })
 
-    async def _call(self, method: str | None, params: dict[str, Any]) -> Any:  # ruff:ignore[any-type]
+    async def _call(
+        self,
+        method: str | None,
+        params: dict[str, Any],
+        ws: web.WebSocketResponse | None = None,
+    ) -> Any:  # ruff:ignore[any-type]
         """Route one method name to the corresponding service call.
 
         Args:
             method: JSON-RPC method name.
             params: JSON-RPC params dict.
+            ws: The connection the request arrived on, used only by
+                ``daemon.identify`` to record that connection's client
+                type. ``None`` (e.g. in the dispatch-completeness test,
+                which calls ``_call`` directly) just means the identity
+                can't be recorded.
 
         Returns:
             JSON-serializable result.
@@ -433,6 +452,11 @@ class ControlServer:
             return {"protocols": self.service.list_protocols()}
         if method == "daemon.ping":
             return await self.service.ping()
+        if method == "daemon.identify":
+            client_type = str(params.get("client_type", "unknown"))
+            if ws is not None:
+                self._clients[ws] = client_type
+            return {}
         if method == "ws.status":
             return dataclasses.asdict(
                 await self.service.dispatch(self.service.ws_status)

--- a/tests/cli/test_remote_shell.py
+++ b/tests/cli/test_remote_shell.py
@@ -114,6 +114,25 @@ class TestConnectionLifecycle:
 
         assert not tap.client.is_connected()
 
+    def test_preloop_identifies_the_connection_as_tap(
+        self, live_control_plane: LiveControlPlane
+    ) -> None:
+        """`preloop` sends `daemon.identify("tap")` so the server's RPC log
+        can attribute this connection's later calls (issue #53).
+        """
+        tap = RemoteTapShell(live_control_plane.url)
+        tap.preloop()
+        try:
+            # tests/ disables reportPrivateUsage (see pyproject.toml) --
+            # reaching into the live server's client registry to observe
+            # the identity `preloop` just sent is deliberate white-box
+            # testing, the same style `live_control_plane.py` itself uses.
+            server = live_control_plane._server  # pyright: ignore[reportPrivateUsage]
+            assert server is not None
+            assert "tap" in server._clients.values()  # pyright: ignore[reportPrivateUsage]
+        finally:
+            tap.postloop()
+
 
 class TestRunLifecycleAlerts:
     """The alert-driven state handling issue #37 specifically calls out."""

--- a/tests/daemon/test_control_server_dispatch_completeness.py
+++ b/tests/daemon/test_control_server_dispatch_completeness.py
@@ -169,6 +169,7 @@ _BUILDER_CALLS: list[tuple[str, tuple[Any, ...]]] = [
     ("run_confirm_breakpoint", (True,)),
     ("protocols_list", ()),
     ("daemon_ping", ()),
+    ("identify", ("tap",)),
     ("run_stop", ()),
     ("ws_status", ()),
     ("ws_ping", ()),

--- a/tests/kiosk/test_main.py
+++ b/tests/kiosk/test_main.py
@@ -30,6 +30,25 @@ from autopipette_kiosk import main as kiosk_main
 from tricca_autopipette.core.pipette_constants import DefaultPaths
 
 
+class TestConnectionLifecycle:
+    def test_lifespan_identifies_the_connection_as_kiosk(
+        self, kiosk_client: TestClient, live_control_plane: LiveControlPlane
+    ) -> None:
+        """The kiosk's `lifespan` sends `daemon.identify("kiosk")` right
+        after connecting, so the server's RPC log can attribute this
+        connection's later calls (issue #53). `kiosk_client` already
+        entered the app's lifespan by the time this test body runs.
+        """
+        del kiosk_client  # only needed to enter the app's lifespan
+        # tests/ disables reportPrivateUsage (see pyproject.toml) --
+        # reaching into the live server's client registry to observe the
+        # identity `lifespan` just sent is deliberate white-box testing,
+        # the same style `live_control_plane.py` itself uses.
+        server = live_control_plane._server  # pyright: ignore[reportPrivateUsage]
+        assert server is not None
+        assert "kiosk" in server._clients.values()  # pyright: ignore[reportPrivateUsage]
+
+
 class TestProtocolListing:
     def test_empty_dir_returns_empty_list(
         self, kiosk_client: TestClient, protocols_dir: Path


### PR DESCRIPTION
Closes #53.

**Change.** Adds a one-time `daemon.identify` control-plane RPC (`ControlRequests.identify`) that both `RemoteTapShell` (`tap`) and the kiosk send, hardcoded to their own fixed string (`"tap"`/`"kiosk"`), right after connecting.

- `ControlServer._clients` upgrades from `set[WebSocketResponse]` to `dict[WebSocketResponse, str]`, mapping each connection to the client type it identified as, defaulting to `"unknown"` for a connection that hasn't (yet) sent `daemon.identify`.
- `_dispatch`'s RPC log line (added in #52) now includes that client type: `Control-plane RPC [tap]: movement.move {...}`.
- `RemoteTapShell.preloop` and the kiosk's `lifespan` each send `daemon.identify` right after connecting; a failure to do so is logged, not fatal.

**Not access control.** Per the issue (and ADR-0002), this is an audit-trail label only — a connection that never identifies itself is served normally, just logged as `"unknown"`. `tapd`/the kiosk remain loopback-only with no auth of any kind.

**Testing.**
- `tests/daemon/test_control_server_dispatch_completeness.py`: added `identify` to the builder-coverage table.
- `tests/cli/test_remote_shell.py`: new test asserting `preloop()` records `"tap"` in the live server's client registry.
- `tests/kiosk/test_main.py`: new test asserting the kiosk's `lifespan` records `"kiosk"` in the live server's client registry.
- Full suite (`pytest`, `pyright`, `ruff check`/`format --check`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)