### PR TITLE
docs: add protocol-authoring guide, generated command reference, and runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ address.
 - [`CLAUDE.md`](CLAUDE.md) — architecture deep-dive: components, the `tapd`
   daemon, domain model, config system, and code style.
 - [`CONTEXT.md`](CONTEXT.md) — glossary of domain terms.
+- [`docs/protocol-authoring.md`](docs/protocol-authoring.md) — how to write
+  a `.pipette` protocol file, with runnable examples.
 - [`config/README.md`](config/README.md) — the layered JSON config system.
 - [`systemd/README.md`](systemd/README.md) — production deployment as
   systemd services, and the network-exposure decisions behind it.

--- a/config/locations/examples_deck.json
+++ b/config/locations/examples_deck.json
@@ -1,0 +1,49 @@
+{
+  "plates": [
+    {
+      "name": "example_tipbox",
+      "type": "tipbox",
+      "x": 100,
+      "y": 20,
+      "z": 5,
+      "dip_top": 5.0,
+      "num_row": 2,
+      "num_col": 5,
+      "spacing_row": 9.0,
+      "spacing_col": 9.0
+    },
+    {
+      "name": "example_waste",
+      "type": "waste_container",
+      "x": 20,
+      "y": 20,
+      "z": 5,
+      "dip_top": 5.0,
+      "num_row": 1,
+      "num_col": 1
+    },
+    {
+      "name": "example_source",
+      "type": "array",
+      "x": 100,
+      "y": 60,
+      "z": 5,
+      "dip_top": 5.0,
+      "num_row": 1,
+      "num_col": 4,
+      "spacing_col": 9.0
+    },
+    {
+      "name": "example_dest",
+      "type": "array",
+      "x": 150,
+      "y": 60,
+      "z": 5,
+      "dip_top": 5.0,
+      "num_row": 2,
+      "num_col": 3,
+      "spacing_row": 9.0,
+      "spacing_col": 9.0
+    }
+  ]
+}

--- a/docs/protocol-authoring.md
+++ b/docs/protocol-authoring.md
@@ -1,0 +1,211 @@
+# Writing a protocol file
+
+A `.pipette` file is plain text: one shell command per line, blank lines
+allowed, `#` starts a comment. Its grammar is exactly `tap`'s own shell
+grammar — anything you can type at the `tap` prompt, you can put in a
+protocol file — so `run <path>` inside `tap` replays the file one line at a
+time, buffers the resulting G-code, and uploads/executes it as a single job
+on the pipette.
+
+This is a task-oriented walkthrough. For the full syntax of every command a
+protocol file can use, see
+[`protocol-command-reference.md`](protocol-command-reference.md), generated
+from the same parsers the shell itself uses.
+
+## Before you start
+
+- **The daemon must be running.** `tap` (and the kiosk) are thin clients of
+  `tapd` and do nothing on their own — start `tapd` first.
+- **Home the machine once.** Most commands (`move`, `pipette`,
+  `aspirate`/`dispense`, tip handling, …) are gated behind a homed-safety
+  interlock and raise `NotHomedError` if the machine hasn't been homed
+  since the daemon started. A protocol file is *not* expected to home
+  itself — do it once via `tap`'s `init` (or `home all`), or the kiosk's
+  Home button, before running any protocol. `homed_axes` then stays true
+  for the rest of the daemon's uptime, so you don't need to repeat it
+  between runs.
+- **Five runnable examples live under `protocols/examples/`.** They aren't
+  reachable from the kiosk's protocol picker (its `/protocols` listing is
+  non-recursive) — run them from `tap` with `run examples/<name>.pipette`.
+  Every example below is one of them, referenced by name so you can open it
+  alongside this guide.
+
+## Your first protocol: homing and movement
+
+[`examples/home_and_move.pipette`](../protocols/examples/home_and_move.pipette):
+
+```
+load_locations examples_deck.json --replace
+init
+move 50 50 30
+move_loc example_source
+```
+
+- `load_locations <file> --replace` loads a deck layout from
+  `config/locations/`. Every example starts with this line, loading the
+  same small `examples_deck.json` deck (a tipbox, a waste container, and
+  two small plates — see "The example deck" below), so each one is
+  runnable standalone with zero setup. `--replace` wipes whatever else was
+  loaded first; without it, `load_locations` is *additive* — a second file
+  adds to the deck rather than replacing it, which is how a real protocol
+  composes a deck from reusable groups.
+- `init` sets the coordinate system and speed, then homes every motor —
+  along with `home`, the only commands exempt from the homed-safety
+  interlock, since they're what performs homing.
+- `move x y z` is an absolute move in millimetres.
+- `move_loc <name>` moves to a named location instead of bare coordinates.
+  For a plate, omitting `--row`/`--col` moves to its *next* well in
+  traversal order (the same cursor `pipette`/`aspirate` advance) rather
+  than a fixed position.
+
+## The example deck
+
+`config/locations/examples_deck.json` defines four locations, deliberately
+small:
+
+| Name | Type | Layout |
+|---|---|---|
+| `example_tipbox` | `tipbox` | 2×5 = 10 tip positions |
+| `example_waste` | `waste_container` | 1×1 |
+| `example_source` | `array` | 1×4 wells |
+| `example_dest` | `array` | 2×3 wells (`A1`…`B3`) |
+
+Because `LocationManager.set_plate` always removes-then-recreates a plate
+on load, running `load_locations examples_deck.json --replace` resets
+every well/tip position to fresh — each example is deterministic and
+repeatable on every run, not just the first.
+
+## A real transfer: tip, pipette, dispose
+
+[`examples/simple_transfer.pipette`](../protocols/examples/simple_transfer.pipette):
+
+```
+load_locations examples_deck.json --replace
+next_tip
+pipette 20 example_source example_dest --keep_tip
+dispose_tip
+```
+
+`pipette <vol_ul> <source> <dest>` is the main command: it aspirates from
+`source` and dispenses into `dest`, picking up a tip automatically if none
+is attached and disposing of it into the waste container when it's done.
+That means the minimal version of this protocol is really just
+
+```
+load_locations examples_deck.json --replace
+pipette 20 example_source example_dest
+```
+
+The example spells out `next_tip`/`dispose_tip` explicitly (with
+`--keep_tip` on the `pipette` line, so there's still a tip on when
+`dispose_tip` runs) to make the three steps of a transfer visible. Reach
+for the explicit form when you need to hold a tip across more than one
+`aspirate`/`dispense` pair — see `splits.pipette` below — or want a
+specific tipbox via `--tipbox`.
+
+⚠️ **A deck needs a waste container.** `dispose_tip` (and `pipette`'s
+default tip-disposal at the end of a transfer) raise `NoWasteContainerError`
+if none is configured. Every example deck includes one
+(`example_waste`) for exactly this reason.
+
+## Multiple liquids
+
+[`examples/multi_liquid.pipette`](../protocols/examples/multi_liquid.pipette):
+
+```
+load_locations examples_deck.json --replace
+switch_liquid water
+pipette 20 example_source example_dest
+load_liquid methanol.json
+switch_liquid methanol
+pipette 15 example_source example_dest
+```
+
+The active liquid profile (`config/liquids/*.json`) drives technique —
+aspirate/dispense speed, waits, prewet cycles, and the pre/post air gaps
+that keep liquid from dripping or contaminating the syringe. `"water"` is
+the built-in default and is already active when a protocol starts;
+`load_liquid <file>` registers another profile from `config/liquids/`
+without activating it, and `switch_liquid <name>` makes a registered
+profile active. Technique resolves **explicit command flag > active
+liquid profile > pipette default**, so e.g. `pipette 20 a b --pre_air_gap
+5` overrides the active liquid's value for just that one call without
+switching liquids.
+
+## Multi-dispense: one aspirate, several destinations
+
+[`examples/splits.pipette`](../protocols/examples/splits.pipette):
+
+```
+load_locations examples_deck.json --replace
+pipette 25 example_source example_dest --splits 'example_dest:12@A1;example_dest:8@B2' --leftover waste
+```
+
+`--splits 'DEST:VOL[@WELL];...'` aspirates once and then dispenses to each
+listed destination in turn — one syringe fill instead of one `pipette` call
+per well, which saves a tip pickup and a trip to the source every time.
+`@WELL` (e.g. `@A1`) is optional; omitting it lets the destination plate's
+own traversal order pick the well, the same as a plain `pipette` without
+`--dest_row`/`--dest_col`. Unlike a plain `pipette`, splits never chunk —
+the whole aspirate volume must fit in the syringe at once, since a single
+aspirate is the point.
+
+Here the splits (12 + 8 = 20μL) don't consume the whole 25μL aspirated, so
+`--leftover` is required to say what happens to the remaining 5μL:
+`keep` retains it in the tip, `waste` verifies a waste container up front
+and disposes of the leftover (and the tip) there. Omitting `--leftover`
+when there's a remainder is an error rather than a silent default, since
+"keep the leftover" and "throw it out" are both real, different choices a
+protocol author has to make explicitly.
+
+## Pausing for an operator
+
+[`examples/breakpoint.pipette`](../protocols/examples/breakpoint.pipette):
+
+```
+load_locations examples_deck.json --replace
+next_tip
+move_loc example_source
+break
+pipette 20 example_source example_dest --keep_tip
+dispose_tip
+```
+
+A bare `break` line pauses the run right there and waits for a human (or a
+remote client) to say whether it should continue. In `tap`, a paused run
+shows up via `continue`/`abort`; the kiosk surfaces the same pause as a
+breakpoint prompt in the UI. Use it for a manual check partway through a
+run — confirming a reagent is loaded, a plate is seated correctly, before
+committing to the rest of the file. Answering "continue" resumes on the
+next line exactly where it left off; answering "abort" raises
+`ProtocolAbortedError` and stops the rest of the file from running (any
+lines already executed are not undone).
+
+## Things to know before you improvise
+
+- **Tip disposal without a waste container is currently unsafe.** If a
+  deck has no `waste_container` configured, a transfer that tries to
+  dispose its tip aborts mid-run with a tip still attached — see issue #15
+  in the project backlog. Always configure a waste container.
+- **`trigger` is a stub.** It validates its channel/state and always
+  reports "not yet implemented" — auxiliary hardware (air, shake, lid)
+  can't be driven from a protocol yet (issue #16).
+- **There's no blowout or touch-off support.** Neither exists in this
+  codebase; don't write a protocol assuming either is available.
+- **A recognized command that fails aborts the rest of the file** — an
+  exception (a not-homed error, an out-of-tips error, a bad `--splits`
+  spec, …) from a real command stops the run there. An *unrecognized*
+  command name (a typo) is more forgiving: it's reported as a failure for
+  that line but does not stop the rest of the file, matching older
+  protocol files' behavior. Don't rely on that tolerance — fix typos
+  rather than assume they'll be silently skipped forever.
+
+## Next steps
+
+- [`protocol-command-reference.md`](protocol-command-reference.md) — every
+  protocol-file command, generated from the real argument parsers.
+- [`config/README.md`](../config/README.md) — the full deck/locations JSON
+  schema (traversal order, well masks, tip inventory) for building a real
+  deck beyond the example one here.
+- `CLAUDE.md` at the repo root — architecture, the daemon's dispatch model,
+  and the pipetting-technique resolution rules in more depth.

--- a/docs/protocol-command-reference.md
+++ b/docs/protocol-command-reference.md
@@ -1,0 +1,512 @@
+<!--
+  GENERATED FILE -- do not edit by hand.
+  Produced by scripts/generate_protocol_reference.py from
+  commands/tap_cmd_parsers.py's TAPCmdParsers. Regenerate with:
+
+      python scripts/generate_protocol_reference.py
+
+  tests/docs/test_protocol_reference_freshness.py fails CI if this file
+  drifts from the generator's output.
+-->
+
+# Protocol command reference
+
+Every command a `.pipette` protocol file may use, one per line, in the
+order `tap`'s `run <path>`/the daemon's protocol replay dispatch them.
+This is the generated syntax reference; for a task-oriented walkthrough of
+writing a protocol file, see
+[`protocol-authoring.md`](protocol-authoring.md).
+
+### `init`
+
+```
+Usage: init
+
+Initialise the pipette: set the coordinate system and speed, then home every motor. Exempt from the homed-safety interlock -- this is what performs homing.
+```
+
+### `home`
+
+```
+Usage: home [-h] motors
+
+Home motors on the pipette.
+
+Positional Arguments:
+  motors      Motors to home: x, y, z, pipette, axis, all, servo
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `move`
+
+```
+Usage: move [-h] x y z
+
+Move to absolute XYZ coordinates.
+
+Positional Arguments:
+  x           X-coordinate in mm
+  y           Y-coordinate in mm
+  z           Z-coordinate in mm
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `move_loc`
+
+```
+Usage: move_loc [-h] [--row ROW] [--col COL] name_loc
+
+Move to a named location.
+
+Positional Arguments:
+  name_loc    Location name
+
+Options:
+  -h, --help  show this help message and exit
+  --row ROW   Row index (for plate locations)
+  --col COL   Column index (for plate locations)
+```
+
+### `move_rel`
+
+```
+Usage: move_rel [-h] [--x X] [--y Y] [--z Z]
+
+Move relative to the current position.
+
+Options:
+  -h, --help  show this help message and exit
+  --x X       X-axis offset in mm (default: 0)
+  --y Y       Y-axis offset in mm (default: 0)
+  --z Z       Z-axis offset in mm (default: 0)
+```
+
+### `aspirate`
+
+```
+Usage: aspirate [-h] [--src_row SRC_ROW] [--src_col SRC_COL]
+                [--pre_air_gap PRE_AIR_GAP_UL]
+                [--post_air_gap POST_AIR_GAP_UL] [--prewet PREWET_CYCLES]
+                [--prewet_vol PREWET_VOL_UL]
+                vol_ul source
+
+Aspirate liquid from a source location.
+
+Positional Arguments:
+  vol_ul                Volume to aspirate in microliters
+  source                Source location name
+
+Options:
+  -h, --help            show this help message and exit
+  --src_row SRC_ROW     Source row index (for plate locations)
+  --src_col SRC_COL     Source column index (for plate locations)
+  --pre_air_gap PRE_AIR_GAP_UL
+                        Air drawn before the liquid in μL (default: active
+                        liquid profile)
+  --post_air_gap POST_AIR_GAP_UL
+                        Air drawn after the liquid in μL (default: active
+                        liquid profile)
+  --prewet PREWET_CYCLES
+                        Prewet cycles before aspirating (default: active
+                        liquid profile)
+  --prewet_vol PREWET_VOL_UL
+                        Volume per prewet cycle in μL (default: active liquid
+                        profile)
+```
+
+### `dispense`
+
+```
+Usage: dispense [-h] [--volume VOLUME] [--dest_row DEST_ROW]
+                [--dest_col DEST_COL] [--wiggle]
+                dest
+
+Dispense liquid to a destination location.
+
+Positional Arguments:
+  dest                  Destination location name
+
+Options:
+  -h, --help            show this help message and exit
+  --volume, -v VOLUME   Volume to dispense in μL (default: all remaining
+                        liquid)
+  --dest_row DEST_ROW   Destination row index (for plate locations)
+  --dest_col DEST_COL   Destination column index (for plate locations)
+  --wiggle              Wiggle tip during dispensing to dislodge residual
+                        droplets
+```
+
+### `pipette`
+
+```
+Usage: pipette [-h] [--dispense_vol DISP_VOL_UL] [--src_row SRC_ROW]
+               [--src_col SRC_COL] [--dest_row DEST_ROW] [--dest_col DEST_COL]
+               [--tipbox TIPBOX_NAME] [--pre_air_gap PRE_AIR_GAP_UL]
+               [--post_air_gap POST_AIR_GAP_UL] [--prewet PREWET_CYCLES]
+               [--prewet_vol PREWET_VOL_UL] [--wiggle] [--keep_tip]
+               [--splits SPLITS] [--leftover {keep,waste}]
+               vol_ul source dest
+
+Transfer liquid from source to destination.
+
+Positional Arguments:
+  vol_ul                Volume to aspirate in microliters
+  source                Source location name
+  dest                  Destination location name
+
+Options:
+  -h, --help            show this help message and exit
+  --dispense_vol, -d DISP_VOL_UL
+                        Volume to dispense if different from the aspirate
+                        volume
+  --src_row SRC_ROW     Source row index (for plate locations)
+  --src_col SRC_COL     Source column index (for plate locations)
+  --dest_row DEST_ROW   Destination row index (for plate locations)
+  --dest_col DEST_COL   Destination column index (for plate locations)
+  --tipbox TIPBOX_NAME  Name of the tipbox to draw from (e.g. tipbox, tipbox2)
+  --pre_air_gap PRE_AIR_GAP_UL
+                        Air drawn before the liquid in μL (default: active
+                        liquid profile)
+  --post_air_gap POST_AIR_GAP_UL
+                        Air drawn after the liquid in μL (default: active
+                        liquid profile)
+  --prewet PREWET_CYCLES
+                        Prewet cycles before aspirating (default: active
+                        liquid profile)
+  --prewet_vol PREWET_VOL_UL
+                        Volume per prewet cycle in μL (default: active liquid
+                        profile)
+  --wiggle              Wiggle tip during dispensing to dislodge residual
+                        droplets
+  --keep_tip            Keep tip attached after the operation (default: eject
+                        tip)
+  --splits SPLITS       Multi-dispense from one aspirate:
+                        'DEST:VOL[@WELL];...', e.g.
+                        'plate_a:12@A1;plate_b:8@C3'. Overrides the dest
+                        argument.
+  --leftover {keep,waste}
+                        What to do with liquid left after --splits dispense.
+                        Required when the splits do not consume the whole
+                        aspirated volume.
+```
+
+### `next_tip`
+
+```
+Usage: next_tip
+
+Pick up the next available tip from the configured tipbox(es), drawing in registration order.
+```
+
+### `eject_tip`
+
+```
+Usage: eject_tip
+
+Eject the current tip in place -- unlike dispose_tip, this does not move to the waste container first.
+```
+
+### `dispose_tip`
+
+```
+Usage: dispose_tip
+
+Move to the configured waste container and eject the current tip into it.
+```
+
+### `change_tip`
+
+```
+Usage: change_tip
+
+Dispose the current tip (if any) and pick up a fresh one.
+```
+
+### `switch_liquid`
+
+```
+Usage: switch_liquid <liquid_name>
+
+Switch the active liquid profile to an already-loaded one (see load_liquid). Affects the technique -- speeds, waits, prewet, air gaps -- used by subsequent aspirate/dispense/pipette commands.
+```
+
+### `load_liquid`
+
+```
+Usage: load_liquid <filename>
+
+Load a new liquid profile from config/liquids/. Does not activate it -- follow with switch_liquid.
+```
+
+### `set`
+
+```
+Usage: set [-h] var value
+
+Set a configuration variable to a new value.
+
+Positional Arguments:
+  var         Variable name: SPEED_FACTOR, VELOCITY_MAX, ACCEL_MAX
+  value       Numeric value to assign
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `coor`
+
+```
+Usage: coor [-h] name x y z
+
+Define a named coordinate location.
+
+Positional Arguments:
+  name        Name for the location
+  x           X-coordinate in mm
+  y           Y-coordinate in mm
+  z           Z-coordinate in mm
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `plate`
+
+```
+Usage: plate [-h] [--dip_top DIP_TOP] [--dip_btm DIP_BTM]
+             [--dip_func DIP_FUNC] [--well_diameter WELL_DIAMETER]
+             [--spacing_row SPACING_ROW] [--spacing_col SPACING_COL]
+             name plate_type num_row num_col x y z
+
+Define a plate at a named location.
+
+Positional Arguments:
+  name                  Name for the plate location
+  plate_type            Plate type: array, singleton, tipbox, waste_container
+  num_row               Number of rows
+  num_col               Number of columns
+  x                     X-coordinate of first well in mm
+  y                     Y-coordinate of first well in mm
+  z                     Z-coordinate of first well in mm
+
+Options:
+  -h, --help            show this help message and exit
+  --dip_top DIP_TOP     Z distance above well to begin dipping in mm (default:
+                        0.0)
+  --dip_btm DIP_BTM     Z distance for full-depth dip in mm (enables linear
+                        strategy)
+  --dip_func DIP_FUNC   Dipping strategy: simple, linear (default: simple)
+  --well_diameter WELL_DIAMETER
+                        Well diameter in mm (required for some dipping
+                        strategies)
+  --spacing_row SPACING_ROW
+                        Row-to-row spacing in mm (default: 9.0)
+  --spacing_col SPACING_COL
+                        Column-to-column spacing in mm (default: 9.0)
+```
+
+### `reset_plate`
+
+```
+Usage: reset_plate [-h] name
+
+Reset a plate's current position to the origin well.
+
+Positional Arguments:
+  name        Plate name
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `reset_plates`
+
+```
+Usage: reset_plates
+
+Reset every plate's traversal cursor to its first well.
+```
+
+### `del_loc`
+
+```
+Usage: del_loc [-h] name
+
+Delete a named location or plate.
+
+Positional Arguments:
+  name        Name of the location to delete
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `clear_locs`
+
+```
+Usage: clear_locs
+
+Delete every location on the deck.
+```
+
+### `load_locations`
+
+```
+Usage: load_locations [-h] [--replace] filename
+
+Load locations from a file. Adds to the deck by default so groups compose; use
+--replace to clear it first.
+
+Positional Arguments:
+  filename    Locations file under config/locations/
+
+Options:
+  -h, --help  show this help message and exit
+  --replace   Clear all existing locations before loading
+```
+
+### `unload_locations`
+
+```
+Usage: unload_locations [-h] name
+
+Unload a single location from the deck by name.
+
+Positional Arguments:
+  name        Name of the location to unload
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `save_locations`
+
+```
+Usage: save_locations [filename]
+
+Save the current deck to config/locations/. filename defaults to 'custom_locations.json' when omitted on a protocol-file line.
+```
+
+### `reset_tips`
+
+```
+Usage: reset_tips [-h] name
+
+Mark a tipbox as full, after physically reloading it.
+
+Positional Arguments:
+  name        Tipbox location name
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `reset_tips_all`
+
+```
+Usage: reset_tips_all
+
+Mark every configured tipbox as full.
+```
+
+### `set_tips`
+
+```
+Usage: set_tips [-h] [--available] name ranges [ranges ...]
+
+Declare which tip positions of a box are consumed (or, with --available, which
+still hold a tip). Replaces the box's current state rather than adding to it.
+
+Positional Arguments:
+  name         Tipbox location name
+  ranges       Well IDs and/or ranges, e.g. A1 or A1:D6
+
+Options:
+  -h, --help   show this help message and exit
+  --available  Treat the ranges as the positions that still hold a tip
+```
+
+### `tips`
+
+```
+Usage: tips [-h] [--db] [name]
+
+Show tip availability, as a per-box map.
+
+Positional Arguments:
+  name        Tipbox to report on (default: all)
+
+Options:
+  -h, --help  show this help message and exit
+  --db        Also show the state persisted in Moonraker's database
+```
+
+### `wait`
+
+```
+Usage: wait [-h] ms
+
+Insert a timed pause into the G-code output.
+
+Positional Arguments:
+  ms          Duration to wait in milliseconds
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `trigger`
+
+```
+Usage: trigger [-h] channel state
+
+Control auxiliary triggers (air, shake, aux). Stub: validates the
+channel/state and always reports 'not yet implemented' -- see issue #16.
+
+Positional Arguments:
+  channel     Trigger channel: air, shake, aux
+  state       Desired state: on, off
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `gcode_print`
+
+```
+Usage: gcode_print [-h] msg
+
+Send a message to be displayed on the pipette screen.
+
+Positional Arguments:
+  msg         Message to display
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `vol_to_steps`
+
+```
+Usage: vol_to_steps [-h] vol
+
+Convert a volume in μL to motor steps.
+
+Positional Arguments:
+  vol         Volume in microliters
+
+Options:
+  -h, --help  show this help message and exit
+```
+
+### `break`
+
+```
+Usage: break
+
+Pause the running protocol and wait for an operator (or remote client) to confirm continue/abort -- not a real AutoPipetteService method, handled specially by the protocol dispatch loop. Choosing abort raises ProtocolAbortedError and stops the rest of the file from running.
+```

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -1,1 +1,8 @@
 This is where protocols are stored.
+
+`examples/` holds five runnable `.pipette` files that accompany
+[`docs/protocol-authoring.md`](../docs/protocol-authoring.md) — a
+task-oriented guide to writing a protocol file, with a walkthrough of each
+example. They aren't listed by the kiosk (its protocol picker only globs
+this top-level directory, not subdirectories); run them from `tap` with
+`run examples/<name>.pipette`.

--- a/protocols/examples/breakpoint.pipette
+++ b/protocols/examples/breakpoint.pipette
@@ -1,0 +1,18 @@
+# breakpoint.pipette
+#
+# A `break` line pauses the run and waits for an operator (`tap`'s
+# `continue`/`abort`, or the kiosk's breakpoint prompt) before continuing --
+# useful for a manual check partway through a protocol, e.g. confirming a
+# reagent is in place. Assumes the machine is already homed.
+
+load_locations examples_deck.json --replace
+
+next_tip
+move_loc example_source
+
+# Pauses here until an operator confirms. Choosing "abort" stops the rest
+# of this file from running; choosing "continue" resumes on the next line.
+break
+
+pipette 20 example_source example_dest --keep_tip
+dispose_tip

--- a/protocols/examples/home_and_move.pipette
+++ b/protocols/examples/home_and_move.pipette
@@ -1,0 +1,20 @@
+# home_and_move.pipette
+#
+# The simplest possible protocol: home the machine, then move around the
+# deck a couple of different ways. Start here if you're writing your first
+# .pipette file -- see docs/protocol-authoring.md.
+
+# Every example self-loads its own deck so it's runnable standalone.
+# --replace wipes whatever else was loaded; fine to run on its own.
+load_locations examples_deck.json --replace
+
+# init sets the coordinate system and speed, then homes every motor -- the
+# only command (besides `home`) exempt from the homed-safety interlock.
+init
+
+# Absolute move, in mm.
+move 50 50 30
+
+# Move to a named location instead of bare coordinates -- with no
+# --row/--col, a plate location moves to its next well in traversal order.
+move_loc example_source

--- a/protocols/examples/multi_liquid.pipette
+++ b/protocols/examples/multi_liquid.pipette
@@ -1,0 +1,17 @@
+# multi_liquid.pipette
+#
+# Two liquids, two transfers, switching technique (speeds/waits/prewet/air
+# gaps) between them. Assumes the machine is already homed.
+
+load_locations examples_deck.json --replace
+
+# "water" is the built-in default liquid profile and is already active, but
+# naming it explicitly makes the switch visible.
+switch_liquid water
+pipette 20 example_source example_dest
+
+# load_liquid registers a profile from config/liquids/ without activating
+# it; switch_liquid is a separate step.
+load_liquid methanol.json
+switch_liquid methanol
+pipette 15 example_source example_dest

--- a/protocols/examples/simple_transfer.pipette
+++ b/protocols/examples/simple_transfer.pipette
@@ -1,0 +1,20 @@
+# simple_transfer.pipette
+#
+# One tip, one transfer, one disposal -- the minimal real pipetting
+# protocol. Assumes the machine is already homed (run home_and_move.pipette
+# first, or `init`/`home all` via tap, if it isn't).
+
+load_locations examples_deck.json --replace
+
+# Pick up a tip explicitly. (pipette below would also pick one up
+# automatically if none were attached -- doing it up front here just makes
+# the three steps of a transfer visible.)
+next_tip
+
+# Transfer 20uL from the first well of example_source to the first well of
+# example_dest. --keep_tip overrides pipette's own default of disposing the
+# tip at the end, so the explicit dispose_tip below has something to do.
+pipette 20 example_source example_dest --keep_tip
+
+# Eject the tip into the configured waste container.
+dispose_tip

--- a/protocols/examples/splits.pipette
+++ b/protocols/examples/splits.pipette
@@ -1,0 +1,15 @@
+# splits.pipette
+#
+# Multi-dispense: one aspirate, then several metered dispenses to different
+# wells of the same plate -- saves a tip pickup and a source trip per
+# destination compared with running `pipette` once per well. Assumes the
+# machine is already homed.
+
+load_locations examples_deck.json --replace
+
+# Aspirate 25uL once, dispense 12uL to A1 and 8uL to B2 of example_dest.
+# 12 + 8 = 20uL, 5uL short of the 25uL aspirated -- --leftover says what to
+# do with that remainder; "waste" verifies a waste container up front and
+# disposes of it (and the tip) there. Omitting --leftover here would be an
+# error rather than silently keeping it.
+pipette 25 example_source example_dest --splits 'example_dest:12@A1;example_dest:8@B2' --leftover waste

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ reportUnknownMemberType = true
 reportUnknownParameterType = true
 reportUnknownVariableType = true
 
-extraPaths = ["src"]
+extraPaths = ["src", "scripts"]
 
 # The service/daemon tests are deliberately white-box: they assert against
 # `service._autopipette`, drive `ControlServer._call` directly, and check
@@ -229,6 +229,7 @@ testpaths = ["tests", "src"]
 
 pythonpath = [
     "src",
+    "scripts",
 ]
 
 addopts = "-ra"

--- a/scripts/generate_protocol_reference.py
+++ b/scripts/generate_protocol_reference.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Generate ``docs/protocol-command-reference.md`` from the real parsers.
+
+A ``.pipette`` protocol file's grammar is exactly the interactive shell's
+own -- ``commands/tap_cmd_parsers.py``'s ``TAPCmdParsers`` is the
+authoritative source (see CLAUDE.md), and this script walks it to render
+one Markdown section per command that ``AutoPipetteService`` actually
+dispatches from a protocol-file line. That command set is fixed here as
+:data:`_COMMANDS` (mirroring ``daemon/service.py``'s ``_LINE_DISPATCH``/
+``_STR_ARG_DISPATCH``, which aren't imported directly since they're private
+to that module) rather than dumping every ``TAPCmdParsers`` parser --
+diagnostic/reporting commands like ``send``/``ws_status``/``ls`` are real
+shell commands but are deliberately not protocol-file-dispatchable at all
+(see ``_LINE_DISPATCH``'s docstring), so listing them here would document
+syntax a protocol file can't actually use.
+
+Run directly to regenerate the committed file:
+
+    python scripts/generate_protocol_reference.py
+
+``tests/docs/test_protocol_reference_freshness.py`` asserts the committed
+file matches this script's current output, and that :data:`_COMMANDS`'s
+names match ``AutoPipetteService``'s real dispatch tables exactly -- so an
+added/renamed/removed protocol command fails CI here rather than letting
+the reference silently drift.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from cmd2 import Cmd2ArgumentParser
+
+from tricca_autopipette.commands.tap_cmd_parsers import TAPCmdParsers
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+_OUTPUT_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "protocol-command-reference.md"
+)
+
+_HEADER = """\
+<!--
+  GENERATED FILE -- do not edit by hand.
+  Produced by scripts/generate_protocol_reference.py from
+  commands/tap_cmd_parsers.py's TAPCmdParsers. Regenerate with:
+
+      python scripts/generate_protocol_reference.py
+
+  tests/docs/test_protocol_reference_freshness.py fails CI if this file
+  drifts from the generator's output.
+-->
+
+# Protocol command reference
+
+Every command a `.pipette` protocol file may use, one per line, in the
+order `tap`'s `run <path>`/the daemon's protocol replay dispatch them.
+This is the generated syntax reference; for a task-oriented walkthrough of
+writing a protocol file, see
+[`protocol-authoring.md`](protocol-authoring.md).
+"""
+
+
+@dataclass(frozen=True)
+class _CommandDoc:
+    """One documented protocol-file command.
+
+    Attributes:
+        name: The bare command name as it appears at the start of a
+            protocol-file line.
+        parser: The command's ``Cmd2ArgumentParser``, or None for a command
+            with no argparse parser (either it takes no arguments, or it
+            takes one bare string argument -- see `manual_usage`).
+        manual_usage: A hand-written ``Usage:`` line plus description, for
+            a command with no `parser` to generate one from.
+    """
+
+    name: str
+    parser: Cmd2ArgumentParser | None = None
+    manual_usage: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate that exactly one of `parser`/`manual_usage` is set.
+
+        Raises:
+            ValueError: If both or neither are set.
+        """
+        if (self.parser is None) == (self.manual_usage is None):
+            raise ValueError(
+                f"{self.name!r} must set exactly one of parser/manual_usage"
+            )
+
+
+#: One entry per protocol-file-dispatchable command, grouped and ordered to
+#: match `CLAUDE.md`'s shell-composition command-set groups. Keep this in
+#: sync with `daemon/service.py`'s `_LINE_DISPATCH`/`_STR_ARG_DISPATCH`
+#: (plus the special-cased `break`) -- the freshness test asserts the name
+#: sets match exactly.
+_COMMANDS: list[_CommandDoc] = [
+    # -- Movement -----------------------------------------------------------
+    _CommandDoc(
+        "init",
+        manual_usage=(
+            "Usage: init\n\n"
+            "Initialise the pipette: set the coordinate system and speed, "
+            "then home every motor. Exempt from the homed-safety interlock "
+            "-- this is what performs homing."
+        ),
+    ),
+    _CommandDoc("home", parser=TAPCmdParsers.parser_home),
+    _CommandDoc("move", parser=TAPCmdParsers.parser_move),
+    _CommandDoc("move_loc", parser=TAPCmdParsers.parser_move_loc),
+    _CommandDoc("move_rel", parser=TAPCmdParsers.parser_move_rel),
+    # -- Pipetting ------------------------------------------------------------
+    _CommandDoc("aspirate", parser=TAPCmdParsers.parser_aspirate),
+    _CommandDoc("dispense", parser=TAPCmdParsers.parser_dispense),
+    _CommandDoc("pipette", parser=TAPCmdParsers.parser_pipette),
+    _CommandDoc(
+        "next_tip",
+        manual_usage=(
+            "Usage: next_tip\n\n"
+            "Pick up the next available tip from the configured "
+            "tipbox(es), drawing in registration order."
+        ),
+    ),
+    _CommandDoc(
+        "eject_tip",
+        manual_usage=(
+            "Usage: eject_tip\n\n"
+            "Eject the current tip in place -- unlike dispose_tip, this "
+            "does not move to the waste container first."
+        ),
+    ),
+    _CommandDoc(
+        "dispose_tip",
+        manual_usage=(
+            "Usage: dispose_tip\n\n"
+            "Move to the configured waste container and eject the current "
+            "tip into it."
+        ),
+    ),
+    _CommandDoc(
+        "change_tip",
+        manual_usage=(
+            "Usage: change_tip\n\n"
+            "Dispose the current tip (if any) and pick up a fresh one."
+        ),
+    ),
+    _CommandDoc(
+        "switch_liquid",
+        manual_usage=(
+            "Usage: switch_liquid <liquid_name>\n\n"
+            "Switch the active liquid profile to an already-loaded one "
+            "(see load_liquid). Affects the technique -- speeds, waits, "
+            "prewet, air gaps -- used by subsequent aspirate/dispense/"
+            "pipette commands."
+        ),
+    ),
+    _CommandDoc(
+        "load_liquid",
+        manual_usage=(
+            "Usage: load_liquid <filename>\n\n"
+            "Load a new liquid profile from config/liquids/. Does not "
+            "activate it -- follow with switch_liquid."
+        ),
+    ),
+    # -- Configuration & locations --------------------------------------------
+    _CommandDoc("set", parser=TAPCmdParsers.parser_set),
+    _CommandDoc("coor", parser=TAPCmdParsers.parser_coor),
+    _CommandDoc("plate", parser=TAPCmdParsers.parser_plate),
+    _CommandDoc("reset_plate", parser=TAPCmdParsers.parser_reset_plate),
+    _CommandDoc(
+        "reset_plates",
+        manual_usage=(
+            "Usage: reset_plates\n\nReset every plate's traversal cursor "
+            "to its first well."
+        ),
+    ),
+    _CommandDoc("del_loc", parser=TAPCmdParsers.parser_del_loc),
+    _CommandDoc(
+        "clear_locs",
+        manual_usage="Usage: clear_locs\n\nDelete every location on the deck.",
+    ),
+    _CommandDoc("load_locations", parser=TAPCmdParsers.parser_load_locations),
+    _CommandDoc("unload_locations", parser=TAPCmdParsers.parser_unload_locations),
+    _CommandDoc(
+        "save_locations",
+        manual_usage=(
+            "Usage: save_locations [filename]\n\n"
+            "Save the current deck to config/locations/. filename defaults "
+            "to 'custom_locations.json' when omitted on a protocol-file "
+            "line."
+        ),
+    ),
+    _CommandDoc("reset_tips", parser=TAPCmdParsers.parser_reset_tips),
+    _CommandDoc(
+        "reset_tips_all",
+        manual_usage=("Usage: reset_tips_all\n\nMark every configured tipbox as full."),
+    ),
+    _CommandDoc("set_tips", parser=TAPCmdParsers.parser_set_tips),
+    _CommandDoc("tips", parser=TAPCmdParsers.parser_tips),
+    # -- Utility --------------------------------------------------------------
+    _CommandDoc("wait", parser=TAPCmdParsers.parser_wait),
+    _CommandDoc("trigger", parser=TAPCmdParsers.parser_trigger),
+    _CommandDoc("gcode_print", parser=TAPCmdParsers.parser_gcode_print),
+    _CommandDoc("vol_to_steps", parser=TAPCmdParsers.parser_vol_to_steps),
+    # -- Control flow -----------------------------------------------------------
+    _CommandDoc(
+        "break",
+        manual_usage=(
+            "Usage: break\n\n"
+            "Pause the running protocol and wait for an operator (or "
+            "remote client) to confirm continue/abort -- not a real "
+            "AutoPipetteService method, handled specially by the protocol "
+            "dispatch loop. Choosing abort raises ProtocolAbortedError and "
+            "stops the rest of the file from running."
+        ),
+    ),
+]
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI colour escapes from rich-argparse's help output.
+
+    Args:
+        text: Help/usage text as produced by a `Cmd2ArgumentParser`, which
+            renders in colour via rich-argparse regardless of TTY.
+
+    Returns:
+        The same text with every ANSI SGR escape sequence removed.
+    """
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _render_command(doc: _CommandDoc) -> str:
+    """Render one command's Markdown section.
+
+    Args:
+        doc: The command to render.
+
+    Returns:
+        A Markdown section: a `###` heading followed by a fenced usage/help
+        block.
+    """
+    if doc.parser is not None:
+        doc.parser.prog = doc.name
+        body = _strip_ansi(doc.parser.format_help()).rstrip()
+    else:
+        assert doc.manual_usage is not None  # guaranteed by __post_init__
+        body = doc.manual_usage
+    return f"### `{doc.name}`\n\n```\n{body}\n```\n"
+
+
+def generate() -> str:
+    """Build the full Markdown reference document.
+
+    Returns:
+        The complete file contents, ready to write to
+        `docs/protocol-command-reference.md`.
+    """
+    sections = [_render_command(doc) for doc in _COMMANDS]
+    return _HEADER + "\n" + "\n".join(sections)
+
+
+def main() -> None:
+    """Regenerate `docs/protocol-command-reference.md` on disk."""
+    _OUTPUT_PATH.write_text(generate(), encoding="utf-8")
+    print(f"Wrote {_OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tricca_autopipette/commands/tap_cmd_parsers.py
+++ b/src/tricca_autopipette/commands/tap_cmd_parsers.py
@@ -933,7 +933,11 @@ class TAPCmdParsers:
     parser_vol_to_steps.add_argument("vol", type=float, help="Volume in microliters")
 
     parser_trigger: Cmd2ArgumentParser = Cmd2ArgumentParser(
-        description="Control auxiliary triggers (air, shake, aux)."
+        description=(
+            "Control auxiliary triggers (air, shake, aux). Stub: validates "
+            "the channel/state and always reports 'not yet implemented' -- "
+            "see issue #16."
+        )
     )
     parser_trigger.add_argument(
         "channel",

--- a/tests/daemon/test_example_protocols.py
+++ b/tests/daemon/test_example_protocols.py
@@ -1,0 +1,82 @@
+"""End-to-end execution tests for the real ``protocols/examples/*.pipette``
+
+files documented in ``docs/protocol-authoring.md``. Unlike
+``tests/daemon/test_service_protocol_run.py`` (which exercises the dispatch
+machinery against small synthetic fixtures under ``tests/fixtures/
+protocols/``), this runs the actual committed example files against the
+real ``protocols/`` and ``config/locations/`` directories -- proving every
+example genuinely executes cleanly end-to-end, not merely that it parses.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fakes.fake_moonraker_state import FakeMoonrakerState
+
+from tricca_autopipette.core.pipette_constants import DefaultPaths
+from tricca_autopipette.daemon.service import AutoPipetteService, ProtocolAbortedError
+
+_EXAMPLES = [
+    "examples/home_and_move.pipette",
+    "examples/simple_transfer.pipette",
+    "examples/multi_liquid.pipette",
+    "examples/splits.pipette",
+    "examples/breakpoint.pipette",
+]
+
+
+@pytest.fixture
+def example_service(service: AutoPipetteService) -> AutoPipetteService:
+    """The ``service`` fixture, pointed at the real ``config/locations/``.
+
+    ``service`` redirects ``location_manager.locations_dir`` to ``tmp_path``
+    so ordinary tests can't leave stray files in the repo -- but these
+    examples' first line is ``load_locations examples_deck.json``, which
+    must resolve against the real committed
+    ``config/locations/examples_deck.json``. Also pre-homes the fake
+    Moonraker state, since every example after ``home_and_move.pipette``
+    assumes the machine is already homed (matching real usage -- see
+    ``docs/protocol-authoring.md``).
+
+    Returns:
+        The same ``service``, mutated in place.
+    """
+    service._autopipette.location_manager.locations_dir = (
+        DefaultPaths.DIR_CONFIG_LOCATIONS
+    )
+    assert isinstance(service.moonraker_state, FakeMoonrakerState)
+    service.moonraker_state.set_homed(True)
+    return service
+
+
+@pytest.mark.parametrize("filename", _EXAMPLES, ids=_EXAMPLES)
+def test_example_protocol_runs_cleanly(
+    filename: str, example_service: AutoPipetteService
+) -> None:
+    """Every committed example executes without raising.
+
+    ``breakpoint.pipette``'s ``break`` line is answered "continue" here, so
+    the whole file runs; ``test_breakpoint_example_aborts_cleanly`` below
+    covers the "abort" path separately.
+    """
+    with patch.object(example_service, "request_breakpoint", return_value=True):
+        example_service._run_protocol_sync(filename)
+
+
+def test_breakpoint_example_aborts_cleanly(
+    example_service: AutoPipetteService,
+) -> None:
+    """Answering ``breakpoint.pipette``'s break with "abort" stops the run.
+
+    The lines after ``break`` (the transfer and disposal) must not run --
+    there's no direct way to observe that from here, but a clean
+    ``ProtocolAbortedError`` (rather than some other exception from a line
+    that shouldn't have executed) is the closest black-box proxy available.
+    """
+    with (
+        patch.object(example_service, "request_breakpoint", return_value=False),
+        pytest.raises(ProtocolAbortedError),
+    ):
+        example_service._run_protocol_sync("examples/breakpoint.pipette")

--- a/tests/docs/test_protocol_reference_freshness.py
+++ b/tests/docs/test_protocol_reference_freshness.py
@@ -1,0 +1,72 @@
+"""Freshness checks for the generated ``docs/protocol-command-reference.md``.
+
+Mirrors ``tests/daemon/test_control_server_dispatch_completeness.py``'s
+"assert a generated-from-code artifact isn't stale" pattern, but for
+``scripts/generate_protocol_reference.py`` instead of ``ControlServer``.
+Two independent checks:
+
+- The committed file's contents match what the generator produces *right
+  now* -- catches someone editing the committed Markdown by hand, or
+  editing a parser's help text without regenerating.
+- The generator's own command list (``_COMMANDS``) names exactly the set of
+  commands ``AutoPipetteService`` actually dispatches from a protocol-file
+  line (``_LINE_DISPATCH``/``_STR_ARG_DISPATCH``, plus the special-cased
+  ``break``) -- catches a protocol command being added/renamed/removed in
+  the daemon without updating the generator to match.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import generate_protocol_reference as gpr
+
+from tricca_autopipette.daemon.service import _LINE_DISPATCH, _STR_ARG_DISPATCH
+
+_REFERENCE_PATH = (
+    Path(__file__).resolve().parents[2] / "docs" / "protocol-command-reference.md"
+)
+
+
+def test_committed_reference_matches_generator_output() -> None:
+    """The committed file must equal the generator's current output.
+
+    A mismatch means either the Markdown was hand-edited, or a
+    ``TAPCmdParsers`` parser/description changed without regenerating --
+    run ``python scripts/generate_protocol_reference.py`` and commit the
+    result.
+    """
+    committed = _REFERENCE_PATH.read_text(encoding="utf-8")
+    generated = gpr.generate()
+
+    assert committed == generated, (
+        "docs/protocol-command-reference.md is stale -- regenerate it with "
+        "`python scripts/generate_protocol_reference.py` and commit the "
+        "result."
+    )
+
+
+def test_command_list_matches_real_protocol_dispatch_tables() -> None:
+    """``_COMMANDS``'s names must match the daemon's real dispatch tables.
+
+    Guards the generator's coverage itself: without this, a command added
+    to ``_LINE_DISPATCH``/``_STR_ARG_DISPATCH`` that nobody added to
+    ``_COMMANDS`` would just be silently missing from the reference, and a
+    stale/renamed entry in ``_COMMANDS`` would document a command that no
+    longer exists.
+    """
+    real_commands = set(_LINE_DISPATCH) | set(_STR_ARG_DISPATCH) | {"break"}
+    documented_commands = {doc.name for doc in gpr._COMMANDS}
+
+    missing = real_commands - documented_commands
+    assert not missing, (
+        f"scripts/generate_protocol_reference.py's _COMMANDS is missing: "
+        f"{sorted(missing)} -- add an entry so the reference documents it."
+    )
+    stale = documented_commands - real_commands
+    assert not stale, (
+        f"scripts/generate_protocol_reference.py's _COMMANDS documents "
+        f"commands no longer dispatched from a protocol file: "
+        f"{sorted(stale)} -- AutoPipetteService's dispatch tables must have "
+        "changed."
+    )


### PR DESCRIPTION
Closes #54.

The last open item from the docs/logging audit (#50/#21/#51/#52/#53/#59
already merged). `commands/tap_cmd_parsers.py` was the only authoritative
reference for what a `.pipette` line may contain — there was no actual
guide for someone writing a protocol file.

## What's here

- **`docs/protocol-authoring.md`** — hand-written, task-oriented
  walkthrough (deck loading, tips, a simple transfer, multi-liquid,
  `--splits` multi-dispense, breakpoints), linking out to the reference at
  the end. Also flags the known gaps from CLAUDE.md so a protocol author
  doesn't get bitten by them: #15's tip-disposal-without-waste-container
  bug and #16's `trigger` stub.
- **`docs/protocol-command-reference.md`** — generated by
  `scripts/generate_protocol_reference.py`, which walks
  `TAPCmdParsers`'s real `Cmd2ArgumentParser` instances. Scoped to exactly
  the commands `AutoPipetteService` actually dispatches from a
  protocol-file line (`_LINE_DISPATCH`/`_STR_ARG_DISPATCH` plus the
  special-cased `break`) rather than every shell command, so it doesn't
  document diagnostic/reporting syntax a protocol file can't use.
- **`tests/docs/test_protocol_reference_freshness.py`** — same
  "generated-artifact-can't-drift" pattern as
  `test_control_server_dispatch_completeness.py`: fails CI if the
  committed Markdown doesn't match the generator's current output, or if
  the generator's command list doesn't match the daemon's real dispatch
  tables.
- **`config/locations/examples_deck.json` + `protocols/examples/*.pipette`**
  — five small, self-contained, git-committed example protocols
  (`home_and_move`, `simple_transfer`, `multi_liquid`, `splits`,
  `breakpoint`), each self-loading the example deck as its first line so
  they're runnable standalone via `tap`'s `run examples/<name>.pipette`
  with zero setup. Not reachable from the kiosk (its `/protocols` glob is
  non-recursive) — deliberately, per the issue.
- **`tests/daemon/test_example_protocols.py`** — runs all five real
  example files end-to-end against a real `AutoPipetteService`, proving
  they execute cleanly rather than merely parse (plus a dedicated
  abort-path test for `breakpoint.pipette`).

## Small supporting changes

- `trigger`'s parser description now says it's a stub (issue #16) so both
  `tap -h`/`help trigger` and the generated reference surface that instead
  of silently documenting a no-op.
- `scripts/` added to pytest's `pythonpath` and pyright's `extraPaths` so
  the generator is importable from its freshness test and type-checks
  cleanly.
- `README.md`/`protocols/README.md` link the new guide.

## Verification

- `ruff check`/`ruff format --check` clean on every touched/new file.
- `pyright`: 0 errors repo-wide.
- `pytest`: 1016 passed. `pytest --doctest-modules`: 1161 passed, 20
  skipped (unrelated `+SKIP` doctests).
- `sphinx-build -W docs docs/_build/html`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
