### PR TITLE
chore: strip stale pyproject.toml TODOs, add issue/PR templates + CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Something in tapd/tap/the kiosk is broken or behaving unexpectedly.
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this. This project drives physical
+        hardware (a gantry, a syringe pump, a tip-ejection servo) through
+        Klipper/Moonraker, so the machine-specific context below matters more
+        here than it would for a typical web app bug report.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which component?
+      options:
+        - tapd (the control daemon)
+        - tap (the interactive shell)
+        - kiosk (the touchscreen web UI)
+        - Config system (config/*.json)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+      placeholder: |
+        1. Ran `tap`, then `pipette 50 plate_a plate_b`
+        2. Expected the transfer to complete
+        3. Instead it raised NotHomedError even though I'd already homed
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        The exact commands or `.pipette` lines, in order, that trigger it.
+        If it only reproduces from a specific deck layout, include the
+        relevant part of your locations file (redact anything sensitive).
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: >-
+        This project doesn't have tagged releases yet (see #22) — run
+        `git rev-parse HEAD` in your checkout, or `pip show tricca-autopipette`
+        if installed as a package.
+      placeholder: e.g. 26c2a8b
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config
+      description: >-
+        The system/locations/liquids/pipette config file(s) involved, if the
+        bug is config-shaped. `config/system/*.json`'s `extends` chain matters
+        too if you're using it.
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: tapd log excerpt
+      description: >-
+        `tapd`'s log (rotating file handler as of #52) is usually the fastest
+        way to see what actually happened on the Moonraker side. Paste the
+        relevant window around the failure.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: moonraker-klipper
+    attributes:
+      label: Moonraker / Klipper version
+      description: Only relevant if the bug looks like a G-code/RPC mismatch.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, a specific pipette/deck model, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backlog map
+    url: https://github.com/Tricca-Technologies-Inc/Tricca_AutoPipette/issues/34
+    about: >-
+      Planned-but-unimplemented work and its dependency order lives here,
+      not in a bug report or feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose new behavior, or a change to existing behavior.
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repo tracks its whole backlog as GitHub issues (see the map,
+        [#34](https://github.com/Tricca-Technologies-Inc/Tricca_AutoPipette/issues/34)).
+        A well-scoped request here may get folded into that backlog rather
+        than actioned standalone — that's expected, not a rejection.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What can't you do today, or what's awkward/unsafe about the current behavior?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should happen instead? Concrete is better than abstract.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why you didn't propose them instead.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else — links, sketches, a related issue number.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for the PR. If this closes an issue, say so explicitly (e.g.
+"Closes #54") so it closes automatically on merge.
+-->
+
+## What this does
+
+<!-- What changed, and why. Link the issue it addresses if there is one. -->
+
+## Verification
+
+<!-- This repo has no CI yet (#19) -- these are run locally and reported here. -->
+
+- [ ] `ruff check .`
+- [ ] `ruff format --check .`
+- [ ] `pyright`
+- [ ] `pytest`
+- [ ] `pytest --doctest-modules`, if you touched a docstring `>>> ` example
+- [ ] `sphinx-build -W docs docs/_build/html`, if you touched a docstring or `docs/`
+
+## Safety-sensitive?
+
+<!--
+Check this if the change touches a physical-safety limit or interlock -- a
+syringe capacity bound, the homed interlock, tip disposal, gantry kinematics,
+or network exposure of hardware control (see the `safety` label in
+docs/agents/triage-labels.md). If checked, say what bounds/tests keep an
+overdrive or unsafe-move failure mode from reaching hardware.
+-->
+
+- [ ] This PR touches safety-sensitive code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thanks for considering a contribution to Tricca AutoPipette. This is a small,
+mostly solo-maintained project driving physical lab hardware — a few notes
+below will save you a round-trip.
+
+## Before you start
+
+- **Read `CLAUDE.md`** at the repo root first. It's the authoritative,
+  up-to-date architecture description (components, the `tapd` daemon, the
+  config system, code style) — more detailed and more current than this file.
+- **Check the backlog.** Planned-but-unimplemented work lives as GitHub
+  issues, starting from the map, [#34](https://github.com/Tricca-Technologies-Inc/Tricca_AutoPipette/issues/34).
+  It carries dependency order and standing findings. Several entries record
+  decisions already taken — read an issue fully before proposing a different
+  shape for it. See `docs/agents/issue-tracker.md` for the tracker's
+  conventions and `docs/agents/triage-labels.md` for what the labels mean.
+- **`safety`-labeled issues need extra care.** That label marks work where a
+  wrong value fails *mechanically* — overdriving a syringe, crashing a
+  gantry — not as a catchable exception. Small diffs in that territory still
+  need a human reviewer and explicit reasoning about the bound being changed.
+
+## Dev setup
+
+```bash
+pip install -e ".[dev]"
+```
+
+Run the daemon first — `tap` and the kiosk are both thin clients of it and do
+nothing useful until it's running:
+
+```bash
+tapd --no-connect       # or --local-connect against a local/mock Moonraker
+```
+
+Then, in another terminal:
+
+```bash
+tap                                    # interactive shell
+uvicorn autopipette_kiosk.main:app --host 127.0.0.1 --port 8000   # kiosk
+```
+
+Both the daemon's control plane and the kiosk are loopback-only with no
+authentication by default — see `systemd/README.md` before changing a bind
+address; that's a security decision, not a convenience toggle.
+
+## Checks
+
+Run all four before opening a PR — there's no CI yet ([#19](https://github.com/Tricca-Technologies-Inc/Tricca_AutoPipette/issues/19)), so this is
+what stands behind a review today:
+
+```bash
+ruff check .
+ruff format .
+pyright
+pytest
+```
+
+If you touched a docstring's `>>> ` example, also run:
+
+```bash
+pytest --doctest-modules
+```
+
+If you touched a docstring or anything under `docs/`, also run:
+
+```bash
+sphinx-build -W docs docs/_build/html
+```
+
+(`-W` treats warnings as errors — this is the check to run before a
+docs-affecting PR, not the plain build.)
+
+## Code style
+
+Briefly, since `CLAUDE.md`'s "Code style" section is authoritative: Python
+3.12+, `from __future__ import annotations`, Google-style docstrings
+enforced repo-wide via ruff's `D`/`DOC` rules (only `tests/**` is exempt from
+`D`, none are exempt from `DOC`), pyright strict mode. Match the surrounding
+file's docstring density and naming rather than introducing a new style
+locally.
+
+## Opening a PR
+
+- Branch off `main`; don't push directly to it.
+- If the PR closes an issue, say so in the description (`Closes #NN`) so it
+  closes automatically on merge.
+- The PR template's verification checklist is the minimum bar — check off
+  what you actually ran, not what you intend to.
+
+## License
+
+By contributing, you agree your contribution is licensed under this
+project's [GPL-3.0-or-later](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ address.
 - [`docs/protocol-authoring.md`](docs/protocol-authoring.md) — how to write
   a `.pipette` protocol file, with runnable examples.
 - [`config/README.md`](config/README.md) — the layered JSON config system.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — dev setup, checks, and how to open a PR.
 - [`systemd/README.md`](systemd/README.md) — production deployment as
   systemd services, and the network-exposure decisions behind it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,8 @@ name = "tricca-autopipette"
 version = "0.1.0"
 description = "Automation software for the Tricca AutoPipette"
 
-# TODO:
-# Replace with your actual minimum supported version.
 requires-python = ">=3.12"
 
-# TODO:
-# Add runtime dependencies here.
 dependencies = [
     "aiohttp",
     "cmd2",
@@ -150,8 +146,6 @@ allowed-confusables = ["×"]
 
 [tool.ruff.lint.isort]
 
-# TODO:
-# Replace with your package name under src/.
 known-first-party = [
     "tricca_autopipette", "autopipette_kiosk"
 ]


### PR DESCRIPTION
Closes #23. Closes #20.

## #23 — strip cookiecutter boilerplate

Deletes the three remaining stale `# TODO:` comments in `pyproject.toml`
(above `requires-python`, `dependencies`, and `known-first-party`) — the
fields they instruct the reader to fill in were already filled in.

The issue named a fourth one (above `[tool.coverage.run] source`) and a
real (non-boilerplate) gap it flagged — `autopipette_kiosk` missing from
that same `source` list — but both were already fixed in an earlier
session. Verified there was nothing left to do on either.

## #20 — issue templates, PR template, CONTRIBUTING.md

The issue's hard decision (GitHub Issues as the single backlog vs.
`docs/TODO.md`) was already resolved when the backlog was migrated (#34).
What was left was the actual templates:

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — structured issue form
  asking for the machine-specific context a stock template wouldn't:
  which component (tapd/tap/kiosk), relevant config, a `tapd` log
  excerpt, Moonraker/Klipper version. Answers the issue's own open
  question about what a bug report for a hardware system needs to ask.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — problem/proposal/
  alternatives, pointing at the backlog map (#34) as the primary home
  for planned-but-unimplemented work.
- **`.github/ISSUE_TEMPLATE/config.yml`** — blank issues stay enabled
  (the maintainer files planning/backlog issues that fit neither
  template) with a contact link to #34.
- **`.github/pull_request_template.md`** — description + a checklist of
  the four local checks (there's no CI yet — #19) + a safety-sensitive
  callout referencing the `safety` label from
  `docs/agents/triage-labels.md`.
- **`CONTRIBUTING.md`** — dev setup, the daemon-first run model
  (`tapd` before `tap`/kiosk), the same four checks, a code-style
  pointer back to `CLAUDE.md`, and how to open a PR. Grounded in what's
  actually true today (no CI, no required approvals) rather than
  aspirational process.
- **`README.md`** — links `CONTRIBUTING.md` alongside the existing docs
  list.

Left the label-taxonomy question alone: `docs/agents/triage-labels.md`
already documents the five canonical roles + `safety`, and the issue
says whatever taxonomy lands here should extend that vocabulary rather
than replace it — no new labels needed for these templates.

## Verification

- `ruff check .` / `pyright` / `pytest`: clean (34 pre-existing
  `tests/**`-only ruff findings unchanged and confirmed unrelated).
- Both new YAML issue forms parse as valid YAML.
- `pip install -e ".[dev]" --dry-run` still resolves cleanly after the
  `pyproject.toml` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
