### PR TITLE
Fix DOC (pydoclint) findings under tests/

### DIFF
--- a/tests/cli/test_remote_shell.py
+++ b/tests/cli/test_remote_shell.py
@@ -46,6 +46,9 @@ def shell(live_control_plane: LiveControlPlane) -> Iterator[RemoteTapShell]:
     plain `io.StringIO()` sidesteps that entirely. `perror` (stderr) has no
     such problem -- it looks up `sys.stderr` fresh each call rather than a
     cached attribute -- so stderr-focused tests below use `capsys` directly.
+
+    Yields:
+        The connected shell, torn down via `postloop()` after the test.
     """
     tap = RemoteTapShell(live_control_plane.url)
     tap.stdout = io.StringIO()
@@ -61,6 +64,9 @@ def _output(shell: RemoteTapShell) -> str:
 
     `Cmd.stdout` is typed as the more general `TextIO`; the `shell` fixture
     always sets it to a real `io.StringIO()`, so narrowing here is safe.
+
+    Returns:
+        Everything written to `shell.stdout` since it was created.
     """
     stream = shell.stdout
     assert isinstance(stream, io.StringIO)
@@ -75,6 +81,9 @@ def protocol_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     call, so patching it for the duration of one test is enough -- no need
     to thread a protocols-dir override through the service/fixture chain the
     way `gcode_path`/`locations_dir` already are in `tests/conftest.py`.
+
+    Returns:
+        The empty temp dir now patched in as the protocols directory.
     """
     monkeypatch.setattr(DefaultPaths, "DIR_PROTOCOL", tmp_path)
     return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ def autopipette() -> AutoPipette:
     pipette, liquid) files — read-only, so this is safe to run against the
     real config/ tree with no fixture files or mocks needed. Locations start
     empty; use ``pipette_with_plates`` for tip/well-dependent tests.
+
+    Returns:
+        A real ``AutoPipette`` with no locations loaded yet.
     """
     config_manager = JsonConfigManager()
     config_manager.load_configs()
@@ -92,14 +95,23 @@ def _add_tipbox_waste_and_plate(autopipette: AutoPipette) -> None:
 
 @pytest.fixture
 def pipette_with_plates(autopipette: AutoPipette) -> AutoPipette:
-    """An ``autopipette`` with a tipbox, waste container, and a well plate."""
+    """An ``autopipette`` with a tipbox, waste container, and a well plate.
+
+    Returns:
+        The same ``autopipette``, now with a tipbox, waste container, and
+        4-well plate wired in.
+    """
     _add_tipbox_waste_and_plate(autopipette)
     return autopipette
 
 
 @pytest.fixture
 def fake_websocket_client() -> FakeWebSocketClient:
-    """A connected `FakeWebSocketClient`, for future service-layer tests."""
+    """A connected `FakeWebSocketClient`, for future service-layer tests.
+
+    Returns:
+        A fresh, connected `FakeWebSocketClient`.
+    """
     return FakeWebSocketClient()
 
 
@@ -118,6 +130,10 @@ def service(tmp_path: Path) -> AutoPipetteService:
     ``save_locations``/``load_locations`` are likewise redirected to
     ``tmp_path``, so dispatching them can't leave stray files in the repo's
     real ``config/locations/``.
+
+    Returns:
+        A real, unconnected ``AutoPipetteService`` with I/O redirected to
+        ``tmp_path`` and an unhomed ``FakeMoonrakerState``.
     """
     svc = AutoPipetteService(
         config_system=DefaultPaths.DIR_CONFIG_SYSTEM / DefaultFilenames.CONFIG_SYSTEM,
@@ -139,6 +155,10 @@ def service_with_plates(service: AutoPipetteService) -> AutoPipetteService:
 
     For pipette-group command tests (aspirate/dispense/transfer/tip
     management), which need real locations to operate on.
+
+    Returns:
+        The same ``service``, now with a tipbox, waste container, and
+        4-well plate wired into its ``AutoPipette``.
     """
     _add_tipbox_waste_and_plate(service._autopipette)
     return service
@@ -156,6 +176,9 @@ def live_control_plane(service: AutoPipetteService) -> Iterator[LiveControlPlane
     with the same unhomed, plate-less ``service`` as the ``service`` fixture;
     use ``live_control_plane.service`` to reach in and adjust it (e.g.
     ``.moonraker_state.set_homed(True)``) before issuing requests.
+
+    Yields:
+        The started ``LiveControlPlane``, stopped after the test.
     """
     plane = LiveControlPlane(service)
     plane.start()
@@ -171,6 +194,9 @@ def live_control_plane_with_plates(
 
     For structured movement/pipette command tests that need real locations
     to operate on, the control-plane counterpart of ``service_with_plates``.
+
+    Yields:
+        The started ``LiveControlPlane``, stopped after the test.
     """
     plane = LiveControlPlane(service_with_plates)
     plane.start()

--- a/tests/core/test_json_config_manager.py
+++ b/tests/core/test_json_config_manager.py
@@ -57,6 +57,10 @@ def _scratch_writer(directory: Path) -> Iterator[Any]:
 
     Yields a ``(name, payload) -> filename`` writer that prefixes each
     filename and tracks it for cleanup once the test using it finishes.
+
+    Yields:
+        A writer callable that writes a prefixed scratch config file into
+        ``directory`` and returns its filename.
     """
     written: list[Path] = []
 
@@ -79,25 +83,44 @@ def write_system_config() -> Iterator[Any]:
 
     Into `DefaultPaths.DIR_LOCAL_SYSTEM`, not `DIR_CONFIG_SYSTEM` --
     ``system/`` is local-only (issue #68).
+
+    Yields:
+        A writer callable that writes a prefixed scratch system config and
+        returns its filename.
     """
     yield from _scratch_writer(DefaultPaths.DIR_LOCAL_SYSTEM)
 
 
 @pytest.fixture
 def write_gantry_config() -> Iterator[Any]:
-    """Write scratch gantry configs, cleaning them up afterwards."""
+    """Write scratch gantry configs, cleaning them up afterwards.
+
+    Yields:
+        A writer callable that writes a prefixed scratch gantry config and
+        returns its filename.
+    """
     yield from _scratch_writer(DefaultPaths.DIR_CONFIG_GANTRY)
 
 
 @pytest.fixture
 def write_pipette_config() -> Iterator[Any]:
-    """Write scratch pipette configs, cleaning them up afterwards."""
+    """Write scratch pipette configs, cleaning them up afterwards.
+
+    Yields:
+        A writer callable that writes a prefixed scratch pipette config and
+        returns its filename.
+    """
     yield from _scratch_writer(DefaultPaths.DIR_CONFIG_PIPETTE)
 
 
 @pytest.fixture
 def write_liquid_config() -> Iterator[Any]:
-    """Write scratch liquid configs, cleaning them up afterwards."""
+    """Write scratch liquid configs, cleaning them up afterwards.
+
+    Yields:
+        A writer callable that writes a prefixed scratch liquid config and
+        returns its filename.
+    """
     yield from _scratch_writer(DefaultPaths.DIR_CONFIG_LIQUIDS)
 
 

--- a/tests/core/test_location_manager.py
+++ b/tests/core/test_location_manager.py
@@ -26,7 +26,11 @@ from tricca_autopipette.core.well import StrategyType, Well
 
 @pytest.fixture
 def locations_dir(tmp_path: Path) -> Path:
-    """A scratch locations directory, so tests never touch the real config."""
+    """A scratch locations directory, so tests never touch the real config.
+
+    Returns:
+        The scratch directory to load/save locations files from.
+    """
     return tmp_path
 
 
@@ -36,7 +40,11 @@ def manager(locations_dir: Path) -> LocationManager:
 
 
 def _write(directory: Path, name: str, payload: dict[str, Any]) -> str:
-    """Write a locations file and return its filename."""
+    """Write a locations file and return its filename.
+
+    Returns:
+        The filename the locations file was written under.
+    """
     (directory / name).write_text(json.dumps(payload), encoding="utf-8")
     return name
 

--- a/tests/core/test_plates.py
+++ b/tests/core/test_plates.py
@@ -47,6 +47,10 @@ def _params(plate_type: str = "array", **kwargs: object) -> PlateParams:
     `PlateArray._gen_wells` lays columns out in *decreasing* x, and
     `Coordinate` rejects negative values, so the template well starts far
     enough right that a 12-column plate at 9 mm pitch stays on the bed.
+
+    Returns:
+        A `PlateParams` for a full `ROWS` x `COLS` plate, with `kwargs`
+        overriding any field.
     """
     base: dict[str, object] = {
         "plate_type": plate_type,

--- a/tests/core/test_tipbox_manager.py
+++ b/tests/core/test_tipbox_manager.py
@@ -30,6 +30,9 @@ def _box(rows: int = 1, cols: int = 3, y: float = 2.0, **kwargs: object) -> TipB
     Columns advance in *decreasing* x and `Coordinate` rejects negatives, so
     the template starts far enough right to keep every well on the bed. `y`
     separates boxes that would otherwise sit on top of each other.
+
+    Returns:
+        A `TipBox` of `rows` x `cols` tips.
     """
     params: dict[str, object] = {
         "plate_type": "tipbox",
@@ -53,6 +56,9 @@ def manager() -> TipBoxManager:
 
     The boxes sit at different y so their wells are physically distinct, as
     two real boxes on a deck would be.
+
+    Returns:
+        A `TipBoxManager` with boxes `"tips_a"` and `"tips_b"` registered.
     """
     mgr = TipBoxManager()
     mgr.register("tips_a", _box(y=2.0))

--- a/tests/daemon/test_control_server_movement.py
+++ b/tests/daemon/test_control_server_movement.py
@@ -24,7 +24,11 @@ from tricca_autopipette.daemon.service import AutoPipetteService
 def _call(
     server: ControlServer, method: str, params: dict[str, object]
 ) -> dict[str, Any]:
-    """Dispatch one control-plane RPC, returning its CommandResult-shaped dict."""
+    """Dispatch one control-plane RPC, returning its CommandResult-shaped dict.
+
+    Returns:
+        The RPC response as a `CommandResult`-shaped dict.
+    """
     return asyncio.run(server._call(method, params))
 
 

--- a/tests/fakes/fake_websocket_client.py
+++ b/tests/fakes/fake_websocket_client.py
@@ -63,7 +63,12 @@ class FakeWebSocketClient:
     def send_jsonrpc(
         self, payload: dict[str, Any], timeout: float = 5.0
     ) -> dict[str, Any]:
-        """Record the request and return the next queued canned response."""
+        """Record the request and return the next queued canned response.
+
+        Returns:
+            The next queued canned response, or ``{"result": {}}`` if the
+            queue is empty.
+        """
         del timeout
         self.sent_requests.append(payload)
         if self._responses:
@@ -77,7 +82,11 @@ class FakeWebSocketClient:
         self.sent_notifications.append((method, params))
 
     def upload_gcode_file(self, file_name: str, file_path: str | Path) -> Future[str]:
-        """Record the upload and return an already-resolved Future."""
+        """Record the upload and return an already-resolved Future.
+
+        Returns:
+            An already-resolved `Future` holding the uploaded file's path.
+        """
         self.uploaded_files.append((file_name, str(file_path)))
         future: Future[str] = Future()
         future.set_result(f"gcodes/{file_name}")
@@ -119,17 +128,30 @@ class FakeWebSocketClient:
         self._message_queue.append(QueuedMessage(type=message_type, data=data or {}))
 
     def pop_message(self) -> QueuedMessage | None:
-        """Pop and return the oldest queued message, or None if empty."""
+        """Pop and return the oldest queued message, or None if empty.
+
+        Returns:
+            The oldest queued message, or None if the queue is empty.
+        """
         return self._message_queue.popleft() if self._message_queue else None
 
     def get_queued_messages(self) -> list[QueuedMessage]:
-        """Drain and return every queued message, in FIFO order."""
+        """Drain and return every queued message, in FIFO order.
+
+        Returns:
+            Every message that was queued, in FIFO order. The queue is
+            empty afterwards.
+        """
         messages = list(self._message_queue)
         self._message_queue.clear()
         return messages
 
     def clear_queue(self) -> int:
-        """Discard all queued messages, returning how many were removed."""
+        """Discard all queued messages, returning how many were removed.
+
+        Returns:
+            The number of messages that were discarded.
+        """
         count = len(self._message_queue)
         self._message_queue.clear()
         return count
@@ -143,7 +165,7 @@ class FakeWebSocketClient:
 
         Raises:
             KeyError: If no handler was registered for `method`.
-        """
+        """  # ruff: ignore[docstring-extraneous-exception]
         self._handlers[method](params)
 
     def is_connected(self) -> bool:

--- a/tests/kiosk/conftest.py
+++ b/tests/kiosk/conftest.py
@@ -26,6 +26,9 @@ def protocols_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     per request (see CLAUDE.md), so patching each module constant directly
     -- not the env vars they were originally read from -- is the only way
     to redirect them per test.
+
+    Returns:
+        The empty temp dir now patched in as both protocol directories.
     """
     monkeypatch.setattr(kiosk_main, "PROTOCOLS_DIR", tmp_path)
     monkeypatch.setattr(DefaultPaths, "DIR_PROTOCOL", tmp_path)
@@ -50,6 +53,9 @@ def kiosk_client(
     long-lived singleton in production) -- tests share that same module
     across the whole session, so leftover state from one test would
     otherwise leak into the next.
+
+    Yields:
+        A `TestClient` for the kiosk app, with its `lifespan` running.
     """
     empty_clients: set[WebSocket] = set()
     monkeypatch.setattr(kiosk_main, "TAPD_CONTROL_URI", live_control_plane.url)

--- a/tests/moonraker/test_moonraker_requests.py
+++ b/tests/moonraker/test_moonraker_requests.py
@@ -700,7 +700,11 @@ _BUILDER_CALLS: list[
 
 @pytest.fixture
 def requests() -> MoonrakerRequests:
-    """A fresh builder instance -- these methods are pure, but stay tidy."""
+    """A fresh builder instance -- these methods are pure, but stay tidy.
+
+    Returns:
+        A fresh `MoonrakerRequests` instance.
+    """
     return MoonrakerRequests()
 
 

--- a/tests/moonraker/test_websocket_client.py
+++ b/tests/moonraker/test_websocket_client.py
@@ -76,7 +76,12 @@ class _RealServer:
         await self._server.wait_closed()
 
     def start(self) -> None:
-        """Start the server thread and block until it's accepting connections."""
+        """Start the server thread and block until it's accepting connections.
+
+        Raises:
+            RuntimeError: If the server doesn't start accepting connections
+                within 5 seconds.
+        """
         self._thread.start()
         if not self._ready.wait(timeout=5):
             raise RuntimeError("Test WebSocket server failed to start")
@@ -96,6 +101,10 @@ def real_server() -> Iterator[ServerFactory]:
     Returns a callable that takes a connection handler and returns the
     `ws://...` URL a `WebSocketClient` can connect to. Every server started
     through it is torn down automatically at the end of the test.
+
+    Yields:
+        A factory that starts a real server for the given handler and
+        returns its URL.
     """
     servers: list[_RealServer] = []
 
@@ -112,7 +121,11 @@ def real_server() -> Iterator[ServerFactory]:
 
 
 def _poll_until(predicate: Callable[[], bool], *, timeout: float = 5.0) -> bool:
-    """Poll `predicate` until it's true or `timeout` seconds have elapsed."""
+    """Poll `predicate` until it's true or `timeout` seconds have elapsed.
+
+    Returns:
+        True if `predicate` became true before `timeout` elapsed, else False.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():

--- a/tests/support/live_control_plane.py
+++ b/tests/support/live_control_plane.py
@@ -72,7 +72,12 @@ class LiveControlPlane:
         await server.stop()
 
     def start(self, *, timeout: float = 5.0) -> None:
-        """Start the server thread and block until `url` is ready to dial."""
+        """Start the server thread and block until `url` is ready to dial.
+
+        Raises:
+            RuntimeError: If the server doesn't become ready within
+                `timeout` seconds.
+        """
         self._thread.start()
         if not self._ready.wait(timeout=timeout):
             raise RuntimeError("Live control plane failed to start")


### PR DESCRIPTION
## Summary
- Adds the missing `Returns`/`Yields` sections (and one `Raises` section) that ruff's `DOC` rules (pydoclint) were flagging across 11 test files -- 34 pre-existing findings, none newly introduced by other work.
- Resolves the open question in #70 in favor of fixing in place (matching #50's rigor) rather than carving `tests/**` out of `DOC`'s per-file-ignore: these fixtures/helpers return/yield real values worth documenting the same as `src/`.
- One `docstring-extraneous-exception` finding (`fake_websocket_client.py`'s `trigger_notification`) is suppressed with the repo's existing `# ruff: ignore[docstring-extraneous-exception]` convention, since the `KeyError` it raises is implicit (a dict subscript), not a `raise` statement ruff's static analysis can see.

## Test plan
- `ruff check .` -- all checks pass (was 34 errors, all in `tests/`)
- `ruff format --check .` -- clean
- `pyright` -- 0 errors
- `pytest` -- 1057 passed

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)