### PR TITLE
Ignore .claude/ (Claude Code local session state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ flycheck_*.py
 *.swp
 *.swo
 
+# Claude Code (local session state, permissions, scheduled-task locks --
+# never repo config; that lives in .claude/CLAUDE.md-adjacent tracked files
+# like CLAUDE.md itself, not under this directory)
+.claude/
+
 # Emacs
 .#*
 \#*\#


### PR DESCRIPTION
\`.claude/\` holds per-machine Claude Code state (\`settings.local.json\`, \`scheduled_tasks.lock\`, tmp files) — never repo config, and never actually tracked, but with no ignore rule it showed up as untracked clutter in \`git status\` on every clone that runs Claude Code. Added next to the existing \`.vscode/\`/\`.idea/\` entries in the "IDE / editor" section.

Confirmed nothing under \`.claude/\` was ever tracked (\`git ls-files | grep .claude\` is empty), so this is a pure ignore-rule addition — nothing to \`git rm\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)