### PR TITLE
Add kiosk browser testing: pytest-playwright + AI-review screenshots

### DIFF
--- a/docs/adr/0003-kiosk-browser-testing-pytest-playwright.md
+++ b/docs/adr/0003-kiosk-browser-testing-pytest-playwright.md
@@ -1,0 +1,57 @@
+# Kiosk browser/screenshot testing: `pytest-playwright`, not Node's Playwright Test
+
+**Status:** accepted
+
+Issue #78 (kiosk frontend JS has zero coverage) named three rough options and
+asked for a `/grill` session before implementation. That session also
+surfaced a second need beyond #78's scope: screenshots specifically so a
+Claude session can visually review its own UI changes, not automated
+pixel-diff regression.
+
+**Decision.** Two separate pieces, both on `pytest-playwright` (Python), not
+Node's `@playwright/test`:
+
+1. **An automated regression suite** — real browser driving real clicks
+   against the kiosk, reusing `tests/kiosk/`'s existing `LiveControlPlane`
+   (real fake-Moonraker-backed `ControlServer`, matching this repo's
+   established mock-only-at-the-Moonraker-boundary discipline) behind a new
+   live-`uvicorn` fixture, since Playwright needs a real socket and
+   `TestClient`'s in-process ASGI transport doesn't provide one. Assertions
+   are DOM-based (`expect(locator).to_have_text()`/`to_have_class()`/etc.)
+   only — no pixel-diffing. No separate `node:test` pure-logic-extraction
+   layer either: the JS (419 lines, all DOM-entangled IIFEs with nothing
+   currently exported) is small enough that Playwright driving the real grid
+   already exercises `tips.js`'s `wellId()`/toggle math end to end.
+2. **A standalone, on-demand screenshot-capture tool** — no assertions, not
+   run as part of `pytest`, parameterized by page/state rather than a fixed
+   inventory. Its only job is producing a PNG for a Claude session to `Read`
+   after touching the kiosk frontend. Runs against the same
+   `LiveControlPlane`-backed fixture as (1).
+
+`pytest-playwright` gets its own dedicated install extra, separate from
+`dev` — folding it into `dev` would put a ~300MB browser-binary download
+(`playwright install chromium`) in the path of every contributor touching
+any part of the repo, not just the kiosk.
+
+**Why not Node's Playwright Test.** Its main edge over the Python bindings is
+first-party `expect(page).to_have_screenshot()` — baseline management,
+`--update-snapshots`, per-OS/browser naming — which only matters for
+automated pixel-diff regression. Since the screenshot need here is AI review,
+not diffing, that edge doesn't apply, and Python wins on practical grounds:
+one process can both start the real kiosk+`LiveControlPlane` backend *and*
+drive the browser, with no cross-language orchestration to boot a Python
+server from a Node test runner — and it avoids this repo's first
+`package.json`.
+
+**Why not a third-party Python snapshot-diff plugin**
+(`pytest-playwright-visual-snapshot` and similar) either: same reasoning —
+there's no automated diffing need to solve, so installing one would be
+unused surface area. If automated visual regression becomes a real need
+later (not just AI review), revisit this decision rather than bolting a
+plugin onto the current shape.
+
+**Baseline/CI stability deliberately deferred.** No CI exists yet (#19).
+Playwright screenshots are OS/font-rendering sensitive across machines, but
+since nothing here diffs against a baseline, that sensitivity doesn't bite
+yet. Revisit (e.g. a Docker-pinned browser image) if/when #19 lands and
+regression-suite runs need to be reproducible across machines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ dev = [
     "sphinx-rtd-theme",
 ]
 
+# Kiosk browser testing (ADR-0003): a real browser driving the kiosk
+# frontend, plus the AI-review screenshot-capture tool. Kept out of `dev` --
+# `playwright install` pulls a real browser binary (~300MB) that most work
+# on this repo never touches.
+browser-test = [
+    "pytest-playwright",
+]
+
 
 # ============================================================================
 # Ruff

--- a/tests/kiosk/browser/capture_screenshot.py
+++ b/tests/kiosk/browser/capture_screenshot.py
@@ -1,0 +1,58 @@
+"""Opt-in kiosk screenshot capture -- for a Claude session's own visual
+review of a UI change (ADR-0003), not an automated test.
+
+Deliberately not named `test_*.py`: it reuses this directory's fixtures
+(`live_kiosk_server_with_plates`, `pytest-playwright`'s `page`) but plain
+`pytest`'s directory-glob collection never picks it up, so it never runs by
+accident. Run it explicitly, naming this file:
+
+    pytest tests/kiosk/browser/capture_screenshot.py \
+        --capture-page=tips --capture-out=/tmp/tips.png
+
+`--capture-page` selects an entry from `PAGES` below -- add one there for a
+new page/state rather than a new script.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page
+from support.live_kiosk_server import LiveKioskServer
+
+PAGES: dict[str, Callable[[Page], None]] = {
+    "run": lambda page: None,  # loaded active by default, nothing to do
+    "tips": lambda page: page.click('.tab-btn[data-page="tips"]'),
+}
+
+
+def test_capture(
+    page: Page,
+    live_kiosk_server_with_plates: LiveKioskServer,
+    pytestconfig: pytest.Config,
+) -> None:
+    """Load `--capture-page` and save a full-page screenshot to `--capture-out`.
+
+    Uses `live_kiosk_server_with_plates` (a tipbox/waste/plate wired up)
+    regardless of which page is requested, so any page can render its full
+    state -- there's no cost to the extra backend data for a page that
+    doesn't use it.
+    """
+    name = pytestconfig.getoption("capture_page")
+    if not name:
+        pytest.skip("pass --capture-page=<name> to run this (see PAGES)")
+    if name not in PAGES:
+        pytest.fail(f"Unknown --capture-page {name!r}; choices: {sorted(PAGES)}")
+
+    page.goto(live_kiosk_server_with_plates.url)
+    PAGES[name](page)
+    page.wait_for_timeout(200)  # let the just-triggered render settle
+
+    out = Path(str(pytestconfig.getoption("capture_out")))
+    page.screenshot(path=out, full_page=True)
+    print(f"\nSaved {name!r} screenshot to {out}")

--- a/tests/kiosk/browser/conftest.py
+++ b/tests/kiosk/browser/conftest.py
@@ -1,0 +1,92 @@
+"""Fixtures for real-browser kiosk tests (ADR-0003).
+
+`pytest-playwright` (the `browser-test` install extra) supplies `page`/
+`browser`/`context`. This module supplies the other half: a real, running
+kiosk HTTP server for `page` to point at, since `fastapi.testclient
+.TestClient` -- what `tests/kiosk/conftest.py`'s `kiosk_client` fixture uses
+-- is an in-process ASGI transport with no real socket a browser can dial.
+
+Files under this directory don't import `playwright` at module scope unless
+guarded by `pytest.importorskip("playwright")` -- that's what lets `pytest`
+skip them cleanly (not error) in a `dev`-only checkout that never installed
+`browser-test`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import WebSocket
+from support.live_control_plane import LiveControlPlane
+from support.live_kiosk_server import LiveKioskServer
+
+from autopipette_kiosk import main as kiosk_main
+
+
+def _start_live_kiosk(
+    live_control_plane: LiveControlPlane, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[LiveKioskServer]:
+    """Point the kiosk app at `live_control_plane` and serve it for real.
+
+    Same module-global reset `tests/kiosk/conftest.py`'s `kiosk_client`
+    fixture does -- `autopipette_kiosk/main.py` keeps run/breakpoint/
+    ws-client state as module globals (a long-lived singleton in
+    production), so tests sharing that module need it reset per test.
+
+    Yields:
+        The started `LiveKioskServer`, stopped after the test.
+    """
+    empty_clients: set[WebSocket] = set()
+    monkeypatch.setattr(kiosk_main, "TAPD_CONTROL_URI", live_control_plane.url)
+    monkeypatch.setattr(kiosk_main, "_current_run", kiosk_main.RunStatus(status="idle"))
+    monkeypatch.setattr(kiosk_main, "_current_breakpoint", None)
+    monkeypatch.setattr(kiosk_main, "_ws_clients", empty_clients)
+
+    server = LiveKioskServer(kiosk_main.app)
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def live_kiosk_server(
+    live_control_plane: LiveControlPlane, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[LiveKioskServer]:
+    """A real, running kiosk HTTP server backed by a plain `live_control_plane`.
+
+    Yields:
+        The started `LiveKioskServer`, stopped after the test.
+    """
+    yield from _start_live_kiosk(live_control_plane, monkeypatch)
+
+
+@pytest.fixture
+def live_kiosk_server_with_plates(
+    live_control_plane_with_plates: LiveControlPlane, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[LiveKioskServer]:
+    """A `live_kiosk_server` whose backend has a tipbox/waste/plate wired up.
+
+    Yields:
+        The started `LiveKioskServer`, stopped after the test.
+    """
+    yield from _start_live_kiosk(live_control_plane_with_plates, monkeypatch)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register options for `capture_screenshot.py`'s opt-in capture tool.
+
+    Not consumed by any collected test -- `capture_screenshot.py` only runs
+    when explicitly named on the command line (its filename doesn't match
+    pytest's default `test_*.py` collection glob), and reads these itself.
+    """
+    parser.addoption(
+        "--capture-page",
+        default=None,
+        help="Kiosk page/state to screenshot (see capture_screenshot.py's PAGES).",
+    )
+    parser.addoption(
+        "--capture-out",
+        default="kiosk_screenshot.png",
+        help="Output PNG path for --capture-page.",
+    )

--- a/tests/kiosk/browser/test_tips_toggle.py
+++ b/tests/kiosk/browser/test_tips_toggle.py
@@ -1,0 +1,73 @@
+"""Real-browser coverage of `tips.js`'s tap-to-toggle math (ADR-0003).
+
+Issue #78 named this the riskiest untested piece: `toggleCell` recomputes a
+tipbox's *entire* consumed-well-id set from `present`/`eligible` and posts
+it wholesale to `/tips/set` (since `config.set_tips` replaces a box's whole
+state, not one cell). A regression here silently misreports or corrupts the
+daemon's tip-presence record. This drives a real click against the real
+rendered grid and checks the round trip against `GET /tips`, not just the
+client-side class toggle -- a client-only assertion could pass while
+`toggleCell`'s posted range list was wrong.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("playwright")
+
+import requests
+from playwright.sync_api import Page, expect
+from support.live_kiosk_server import LiveKioskServer
+
+PRESENT = re.compile(r"\bpresent\b")
+
+
+def test_tapping_a_present_cell_marks_it_consumed_end_to_end(
+    page: Page, live_kiosk_server_with_plates: LiveKioskServer
+) -> None:
+    page.goto(live_kiosk_server_with_plates.url)
+    page.click('.tab-btn[data-page="tips"]')
+
+    card = page.locator('.tipbox-card[data-box="tipbox"]')
+    cell_a1 = card.locator('.tip-cell[data-index="0"]')
+    expect(cell_a1).to_have_class(PRESENT)  # box starts full (see test_main.py)
+
+    cell_a1.click()
+
+    # tips.js's toggleCell always calls loadTips() in a `finally`, which
+    # tears down and rebuilds the grid -- re-querying via the locator (not
+    # holding the old element handle) is what lets this wait past that
+    # rebuild instead of racing it.
+    expect(card.locator('.tip-cell[data-index="0"]')).not_to_have_class(PRESENT)
+    expect(card.locator('.tip-cell[data-index="1"]')).to_have_class(PRESENT)
+
+    # The client-side class flip alone can't distinguish "toggled the right
+    # cell" from "toggled the wrong one and re-rendered anyway" -- confirm
+    # against the server's own record, the same `GET /tips` tips.js itself
+    # polls after every toggle.
+    listing = requests.get(
+        f"{live_kiosk_server_with_plates.url}/tips", timeout=5
+    ).json()
+    assert listing["data"]["boxes"][0]["present"] == [False, True]
+
+
+def test_tapping_again_restores_it(
+    page: Page, live_kiosk_server_with_plates: LiveKioskServer
+) -> None:
+    page.goto(live_kiosk_server_with_plates.url)
+    page.click('.tab-btn[data-page="tips"]')
+    card = page.locator('.tipbox-card[data-box="tipbox"]')
+    cell_a1 = card.locator('.tip-cell[data-index="0"]')
+
+    cell_a1.click()
+    expect(card.locator('.tip-cell[data-index="0"]')).not_to_have_class(PRESENT)
+    card.locator('.tip-cell[data-index="0"]').click()
+    expect(card.locator('.tip-cell[data-index="0"]')).to_have_class(PRESENT)
+
+    listing = requests.get(
+        f"{live_kiosk_server_with_plates.url}/tips", timeout=5
+    ).json()
+    assert listing["data"]["boxes"][0]["present"] == [True, True]

--- a/tests/support/live_kiosk_server.py
+++ b/tests/support/live_kiosk_server.py
@@ -1,0 +1,65 @@
+"""A real kiosk HTTP server, run on its own thread, for browser-driven tests.
+
+Playwright needs a real ``http://`` socket to point a browser at --
+`fastapi.testclient.TestClient`'s in-process ASGI transport (what
+`tests/kiosk/conftest.py`'s `kiosk_client` fixture uses) doesn't provide one.
+Mirrors `tests/support/live_control_plane.py`'s shape: its own background
+thread, so a synchronous test body (Playwright's sync API included) can
+block freely without starving the server's own event loop.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import uvicorn
+from fastapi import FastAPI
+
+
+class LiveKioskServer(uvicorn.Server):
+    """A real `uvicorn` server for the kiosk app, bound to an ephemeral port.
+
+    Attributes:
+        url: The `http://127.0.0.1:<port>` base URL, valid once `start()`
+            returns.
+    """
+
+    def __init__(self, app: FastAPI) -> None:
+        """Configure the server; nothing runs until `start()`.
+
+        Args:
+            app: The kiosk's FastAPI app (`autopipette_kiosk.main.app`),
+                with `TAPD_CONTROL_URI` and the run/breakpoint/ws-client
+                module globals already patched to a test backend -- same
+                setup `tests/kiosk/conftest.py`'s `kiosk_client` does.
+        """
+        config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+        super().__init__(config)
+        self.url = ""
+        self._thread = threading.Thread(target=self.run, daemon=True)
+
+    def install_signal_handlers(self) -> None:
+        """No-op: uvicorn's default SIGINT/SIGTERM handlers need the main
+        thread, but this server runs on a background one."""
+
+    def start(self, *, timeout: float = 5.0) -> None:
+        """Start the server thread and block until `url` is ready to dial.
+
+        Raises:
+            RuntimeError: If the server doesn't become ready within
+                `timeout` seconds.
+        """
+        self._thread.start()
+        deadline = time.monotonic() + timeout
+        while not self.started:
+            if time.monotonic() > deadline:
+                raise RuntimeError("Live kiosk server failed to start")
+            time.sleep(1e-3)
+        host, port = self.servers[0].sockets[0].getsockname()[:2]
+        self.url = f"http://{host}:{port}"
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        """Signal shutdown and join the server thread."""
+        self.should_exit = True
+        self._thread.join(timeout=timeout)


### PR DESCRIPTION
Closes #78.

## What this does

Two pieces, both on `pytest-playwright` (Python), not Node's Playwright
Test — see `docs/adr/0003-kiosk-browser-testing-pytest-playwright.md` for
the full reasoning (settled via a `/grill` session before implementation):

- **An automated DOM-assertion regression suite** (`tests/kiosk/browser/`),
  driving a real browser against a real `uvicorn`-served kiosk backed by
  the existing `LiveControlPlane` fixture — `TestClient`'s in-process ASGI
  transport doesn't give Playwright a real socket to dial, so this adds
  `tests/support/live_kiosk_server.py` to provide one. First slice covers
  `tips.js`'s tap-to-toggle math end to end (DOM state *and* a follow-up
  `GET /tips`, so "toggled the wrong cell but re-rendered anyway" can't
  hide behind a DOM-only assertion) — issue #78's named riskiest gap.
  `app.js`/`run.js` are still untested; extending that is left to land
  incrementally per `/tdd` as those get touched, not as a bulk follow-up.

- **A standalone screenshot-capture tool**
  (`tests/kiosk/browser/capture_screenshot.py`), added because the
  screenshots wanted here are for a Claude session to visually review its
  own UI changes, not automated pixel-diff regression — no assertions, not
  run as part of plain `pytest` (no `test_` prefix, so default collection
  skips it), parameterized by page/state via `--capture-page`.

`pytest-playwright` lives in a new `browser-test` extra, kept separate from
`dev` so the ~300MB browser download isn't in every contributor's path.
Browser test files guard their `playwright` import with
`pytest.importorskip` so a `dev`-only checkout skips them cleanly instead
of erroring (verified both ways).

## Verification

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pyright`
- [x] `pytest` (1067 passed, incl. the 2 new browser tests + confirmed
      clean skip without `browser-test` installed)
- [ ] `pytest --doctest-modules` — no `>>> ` examples touched
- [x] `sphinx-build -W docs docs/_build/html`

## Safety-sensitive?

- [ ] This PR touches safety-sensitive code