### PR TITLE
Add browser coverage for app.js and run.js

### DIFF
--- a/tests/kiosk/browser/test_run_page.py
+++ b/tests/kiosk/browser/test_run_page.py
@@ -1,0 +1,64 @@
+"""Real-browser coverage of `run.js`: protocol list/selection, and the
+run-status pipeline it shares with `app.js`'s status pill (ADR-0003 /
+issue #78).
+
+The run test below is the other named gap from issue #78 beyond `tips.js`'s
+toggle math: "the client-side WebSocket message handling." It drives a real
+`/run` POST through the real daemon and checks the real `notify_run_status`
+push lands on *both* app.js's shared pill and run.js's own status card --
+proof the two independently-subscribed listeners (`App.onStatus`) both
+actually receive it, not just one. It stops at "running": nothing in this
+fake-Moonraker-backed test setup ever fires a print-completion event (see
+`tests/fakes/fake_moonraker_state.py`), so a "done" transition isn't
+reachable here yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect
+from support.live_kiosk_server import LiveKioskServer
+
+
+def test_empty_protocol_list_shows_a_placeholder(
+    page: Page, live_kiosk_server: LiveKioskServer, protocols_dir: Path
+) -> None:
+    del protocols_dir  # exists (redirected), just empty
+    page.goto(live_kiosk_server.url)
+
+    expect(page.locator("#protocolList")).to_contain_text("No .pipette files found")
+
+
+def test_selecting_a_protocol_enables_run_and_shows_its_name(
+    page: Page, live_kiosk_server: LiveKioskServer, protocols_dir: Path
+) -> None:
+    (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+    page.goto(live_kiosk_server.url)
+    expect(page.locator(".protocol-item")).to_have_count(1)
+
+    page.click(".protocol-item")
+
+    expect(page.locator("#selectionName")).to_have_text("a")
+    expect(page.locator("#runBtn")).to_be_enabled()
+
+
+def test_running_a_protocol_updates_the_shared_pill_and_the_run_page_card(
+    page: Page, live_kiosk_server: LiveKioskServer, protocols_dir: Path
+) -> None:
+    (protocols_dir / "a.pipette").write_text('gcode_print "hi"\n')
+    page.goto(live_kiosk_server.url)
+    page.click(".protocol-item")
+
+    page.click("#runBtn")
+
+    # app.js's shared status pill (visible regardless of active tab)...
+    expect(page.locator("#statusPillLabel")).to_have_text("Running")
+    # ...and run.js's own detailed status card -- both driven by the same
+    # real notify_run_status push, relayed over the real /ws/status socket.
+    expect(page.locator("#statusState")).to_have_text("Running")
+    expect(page.locator("#runBtn")).to_be_disabled()

--- a/tests/kiosk/browser/test_tab_switching.py
+++ b/tests/kiosk/browser/test_tab_switching.py
@@ -1,0 +1,72 @@
+"""Real-browser coverage of `app.js`: the tab switcher and connection
+indicator (ADR-0003 / issue #78).
+
+`App.registerPage`/`App.switchTo` is the mechanism every current and future
+kiosk page hangs its lifecycle hooks off of -- a regression here (a page
+stuck active, or `onShow` never firing on switch) silently breaks every
+page, not just one, which is why it gets its own file rather than living
+inside `test_run_page.py`/`test_tips_toggle.py`.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect
+from support.live_kiosk_server import LiveKioskServer
+
+ACTIVE = re.compile(r"\bactive\b")
+LIVE = re.compile(r"\blive\b")
+
+
+def test_run_tab_is_active_on_load(
+    page: Page, live_kiosk_server: LiveKioskServer
+) -> None:
+    # A full reload always lands on Run, never a persisted tab -- see
+    # app.js's `initTabBar` docstring.
+    page.goto(live_kiosk_server.url)
+
+    expect(page.locator('.tab-btn[data-page="run"]')).to_have_class(ACTIVE)
+    expect(page.locator("#page-run")).to_have_class(ACTIVE)
+    expect(page.locator("#page-tips")).not_to_have_class(ACTIVE)
+
+
+def test_clicking_tips_switches_pages_and_fires_its_onshow(
+    page: Page, live_kiosk_server_with_plates: LiveKioskServer
+) -> None:
+    page.goto(live_kiosk_server_with_plates.url)
+
+    page.click('.tab-btn[data-page="tips"]')
+
+    expect(page.locator('.tab-btn[data-page="tips"]')).to_have_class(ACTIVE)
+    expect(page.locator("#page-tips")).to_have_class(ACTIVE)
+    expect(page.locator('.tab-btn[data-page="run"]')).not_to_have_class(ACTIVE)
+    expect(page.locator("#page-run")).not_to_have_class(ACTIVE)
+    # tips.js's onShow (loadTips) actually ran -- a real `GET /tips`
+    # rendered the box, not just the tab/page classes flipping.
+    expect(page.locator('.tipbox-card[data-box="tipbox"]')).to_be_visible()
+
+
+def test_clicking_back_to_run_restores_it(
+    page: Page, live_kiosk_server: LiveKioskServer
+) -> None:
+    page.goto(live_kiosk_server.url)
+    page.click('.tab-btn[data-page="tips"]')
+
+    page.click('.tab-btn[data-page="run"]')
+
+    expect(page.locator("#page-run")).to_have_class(ACTIVE)
+    expect(page.locator("#page-tips")).not_to_have_class(ACTIVE)
+
+
+def test_status_websocket_connects(
+    page: Page, live_kiosk_server: LiveKioskServer
+) -> None:
+    page.goto(live_kiosk_server.url)
+
+    expect(page.locator("#connDot")).to_have_class(LIVE)
+    expect(page.locator("#connLabel")).to_have_text("live")


### PR DESCRIPTION
Follow-on to #80, filling the other two gaps issue #78 named alongside
`tips.js`: the tab switcher/connection indicator (`app.js`) and the
protocol list/run lifecycle (`run.js`). Same pattern as the `tips.js`
slice — real browser, real backend via `LiveControlPlane`, no mocking.

## What this does

- `test_tab_switching.py`: `App.registerPage`/`switchTo` — the mechanism
  every current and future kiosk page hangs its lifecycle hooks off of, so
  a regression here silently breaks every page, not just one. Also covers
  the `/ws/status` connection indicator. Verified these actually catch a
  regression (not just pass vacuously) by temporarily breaking
  `switchTo`'s page-class toggle and confirming the tab test fails, then
  restoring it.
- `test_run_page.py`: protocol list rendering/selection, and a real
  `POST /run` whose `notify_run_status` push is checked against *both*
  `app.js`'s shared status pill and `run.js`'s own status card — proof
  both independent `App.onStatus` listeners actually receive it. Stops at
  "running": this fake-Moonraker-backed test setup has no seam yet to
  fire a print-completion event, so "done" isn't reachable here without
  reaching into a private test fake.

All three kiosk JS files (`app.js`/`run.js`/`tips.js`) now have real
browser coverage.

## Verification

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pyright`
- [x] `pytest` (1074 passed)
- [ ] `pytest --doctest-modules` — no `>>> ` examples touched
- [ ] `sphinx-build -W docs docs/_build/html` — no docstrings/`docs/` touched

## Safety-sensitive?

- [ ] This PR touches safety-sensitive code