### PR TITLE
Codebase quality sweep: dead code, dedup, real bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiohttp",
     "cmd2",
-    "opencv-python",
     "pydantic>=2",
-    "requests",
     "websockets",
     "numpy",
     "fastapi",

--- a/src/autopipette_kiosk/main.py
+++ b/src/autopipette_kiosk/main.py
@@ -19,11 +19,10 @@ See systemd/README.md before exposing it.
 import asyncio
 import logging
 import os
-import re
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
@@ -37,7 +36,11 @@ from tricca_autopipette.commands.tap_cmd_parsers import (
 )
 from tricca_autopipette.core.pipette_constants import DefaultPaths
 from tricca_autopipette.daemon.control_requests import ControlRequests
-from tricca_autopipette.moonraker.websocket_client import WebSocketClient
+from tricca_autopipette.moonraker.websocket_client import (
+    JsonRpcError,
+    WebSocketClient,
+    as_dict,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,8 +133,6 @@ _current_run: RunStatus = RunStatus(status="idle")
 # "filename", "pending"} while one is awaiting a response, None otherwise.
 _current_breakpoint: dict[str, Any] | None = None
 _ws_clients: set[WebSocket] = set()
-
-_ERROR_TYPE_RE = re.compile(r"'type':\s*'([^']+)'")
 
 
 @asynccontextmanager
@@ -268,12 +269,13 @@ async def run_protocol(req: RunRequest) -> RunStatus:
         response = await asyncio.to_thread(
             _control_client.send_jsonrpc, _control_requests.run_start(req.filename)
         )
-    except RuntimeError as exc:
-        error_type = _extract_error_type(exc)
-        if error_type == "RunAlreadyActiveError":
+    except JsonRpcError as exc:
+        if exc.error_type == "RunAlreadyActiveError":
             raise HTTPException(status_code=409, detail=str(exc)) from exc
-        if error_type == "FileNotFoundError":
+        if exc.error_type == "FileNotFoundError":
             raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     result: dict[str, Any] = response.get("result", {})
@@ -370,7 +372,7 @@ async def _dispatch_tips_request(request: dict[str, Any]) -> TipsResult:
 
     result: dict[str, Any] = response.get("result", {})
     return TipsResult(
-        ok=bool(result.get("ok", False)),
+        ok=bool(result.get("ok")),
         message=str(result.get("message", "")),
         data=result.get("data"),
     )
@@ -451,26 +453,6 @@ async def status_ws(websocket: WebSocket) -> None:
 
 
 # ── internal ───────────────────────────────────────────────────────────────────
-def _extract_error_type(exc: RuntimeError) -> str | None:
-    """Recover the daemon's error type name from a control-plane RuntimeError.
-
-    `WebSocketClient.send_jsonrpc` raises `RuntimeError(f"Server error:
-    {data['error']}")` on any control-plane error response, folding the
-    structured `{"type": ..., "message": ...}` error payload into a string.
-    This picks the type name back out so callers can map it to an HTTP
-    status code without matching on message text.
-
-    Args:
-        exc: The RuntimeError raised by `send_jsonrpc`.
-
-    Returns:
-        The error's type name (e.g. "RunAlreadyActiveError"), or None if it
-        could not be recovered.
-    """
-    match = _ERROR_TYPE_RE.search(str(exc))
-    return match.group(1) if match else None
-
-
 def _on_run_status_notification(params: Any) -> None:  # ruff:ignore[any-type]
     """Handle a `notify_run_status` push from the tapd control daemon.
 
@@ -485,7 +467,7 @@ def _on_run_status_notification(params: Any) -> None:  # ruff:ignore[any-type]
     global _current_run, _current_breakpoint
     if not isinstance(params, dict):
         return
-    notification = cast("dict[str, Any]", params)
+    notification = as_dict(params)
     _current_run = RunStatus(
         status=notification.get("status", "idle"),
         message=notification.get("message", ""),
@@ -514,7 +496,7 @@ def _on_breakpoint_notification(params: Any) -> None:  # ruff:ignore[any-type]
     global _current_breakpoint
     if not isinstance(params, dict):
         return
-    notification = cast("dict[str, Any]", params)
+    notification = as_dict(params)
     _current_breakpoint = notification if notification.get("pending") else None
     if _main_loop is not None:
         asyncio.run_coroutine_threadsafe(_broadcast_status(), _main_loop)

--- a/src/tricca_autopipette/cli/remote_shell.py
+++ b/src/tricca_autopipette/cli/remote_shell.py
@@ -72,27 +72,12 @@ from tricca_autopipette.commands.tap_cmd_parsers import (
     args_from_namespace,
 )
 from tricca_autopipette.daemon.control_requests import ControlRequests
-from tricca_autopipette.moonraker.websocket_client import WebSocketClient
+from tricca_autopipette.moonraker.websocket_client import WebSocketClient, as_dict
 from tricca_autopipette.resources.string_constants import TAP_CLR_BANNER
 
 logger = logging.getLogger(__name__)
 
 WEBSOCKET_TIMEOUT_SECONDS = 10
-
-
-def _as_dict(value: Any) -> dict[str, Any]:  # ruff:ignore[any-type]
-    """Narrow a loosely-typed JSON-RPC result/params value to a dict.
-
-    Args:
-        value: Value to narrow, typically a JSON-RPC ``result`` or
-            notification ``params`` of otherwise unknown shape.
-
-    Returns:
-        ``value`` if it is a dict, otherwise an empty dict.
-    """
-    if isinstance(value, dict):
-        return cast("dict[str, Any]", value)
-    return {}
 
 
 class RemoteTapShell(Cmd):
@@ -159,7 +144,7 @@ class RemoteTapShell(Cmd):
             params: `{"status", "message", "run_id", "filename"}` as sent by
                 `AutoPipetteService._broadcast_status`.
         """
-        notification = _as_dict(params)
+        notification = as_dict(params)
         if not notification:
             return
         status = notification.get("status")
@@ -173,7 +158,7 @@ class RemoteTapShell(Cmd):
             params: `{"run_id", "filename", "pending"}` as sent by
                 `AutoPipetteService.request_breakpoint`/`confirm_breakpoint`.
         """
-        notification = _as_dict(params)
+        notification = as_dict(params)
         if notification.get("pending"):
             self.add_alert(
                 msg="⏸ Protocol paused at a breakpoint. "
@@ -417,14 +402,14 @@ class RemoteTapShell(Cmd):
             return
         # {"protocols": [{"name": stem, "filename": name}, ...]} -- a plain
         # dict, not the CommandResult "data" envelope _result_data expects.
-        protocols: list[dict[str, Any]] = _as_dict(response.get("result")).get(
-            "protocols"
-        ) or []
+        protocols: list[dict[str, Any]] = (
+            as_dict(response.get("result")).get("protocols") or []
+        )
         if not protocols:
             self.poutput("No protocol files found.")
             return
         for protocol in protocols:
-            self.poutput(str(_as_dict(protocol).get("filename", "")))
+            self.poutput(str(as_dict(protocol).get("filename", "")))
 
     def _confirm_breakpoint(self, *, proceed: bool) -> None:
         """Send a breakpoint confirmation to the daemon.
@@ -505,8 +490,8 @@ class RemoteTapShell(Cmd):
         response = self._send(self.requests.ws_status())
         if response is None:
             return
-        result = _as_dict(response.get("result"))
-        data = _as_dict(result.get("data"))
+        result = as_dict(response.get("result"))
+        data = as_dict(result.get("data"))
         if "queued_messages" not in data:
             # No Moonraker client configured at all (`tapd --no-connect`) --
             # only the configured URI is known, not live connection details.
@@ -535,7 +520,7 @@ class RemoteTapShell(Cmd):
             return
         # {"connected_to_moonraker": bool} -- a plain dict, not the
         # CommandResult "data" envelope _result_data expects.
-        connected = _as_dict(response.get("result")).get("connected_to_moonraker")
+        connected = as_dict(response.get("result")).get("connected_to_moonraker")
         self.poutput(
             "Connected to Moonraker" if connected else "Not connected to Moonraker"
         )
@@ -564,12 +549,12 @@ class RemoteTapShell(Cmd):
         response = self._send(self.requests.clients())
         if response is None:
             return
-        clients: list[Any] = _as_dict(response.get("result")).get("clients") or []
+        clients: list[Any] = as_dict(response.get("result")).get("clients") or []
         if not clients:
             self.poutput("(no clients connected)")
             return
         for client in clients:
-            self.poutput(str(_as_dict(client).get("client_type", "unknown")))
+            self.poutput(str(as_dict(client).get("client_type", "unknown")))
 
     @with_argparser(TAPCmdParsers.parser_send)  # type: ignore[arg-type]
     def do_send(self, args: SendArgs) -> None:
@@ -580,7 +565,7 @@ class RemoteTapShell(Cmd):
         response = self._send(self.requests.ws_send(args.method, params))
         if response is None:
             return
-        data = _as_dict(_as_dict(response.get("result")).get("data"))
+        data = as_dict(as_dict(response.get("result")).get("data"))
         self.poutput(json.dumps(data.get("response"), indent=2))
 
     @with_argparser(TAPCmdParsers.parser_notify)  # type: ignore[arg-type]
@@ -686,8 +671,8 @@ class RemoteTapShell(Cmd):
         )
         if response is None:
             return
-        result = _as_dict(response.get("result"))
-        data = _as_dict(result.get("data"))
+        result = as_dict(response.get("result"))
+        data = as_dict(result.get("data"))
 
         volumes_ul: list[float] = data.get("volumes_ul") or []
         travel_mm: list[float] = data.get("travel_mm") or []
@@ -729,7 +714,7 @@ class RemoteTapShell(Cmd):
         """
         if response is None:
             return None
-        return _as_dict(_as_dict(response.get("result")).get("data"))
+        return as_dict(as_dict(response.get("result")).get("data"))
 
     def _parse_json_params(
         self, raw: str | None
@@ -761,7 +746,7 @@ class RemoteTapShell(Cmd):
         if response is None:
             return
         raw_result: Any = response.get("result")
-        result = _as_dict(raw_result)
+        result = as_dict(raw_result)
         if "status" in result:
             # run.*-shaped reply: {"status", "message", "run_id", "filename"}.
             self.poutput(f"{result.get('status')}: {result.get('message', '')}")
@@ -800,7 +785,7 @@ class RemoteTapShell(Cmd):
             response = self.client.send_jsonrpc(self.requests.ws_status())
         except RuntimeError:
             return
-        data = _as_dict(_as_dict(response.get("result")).get("data"))
+        data = as_dict(as_dict(response.get("result")).get("data"))
         uri = data.get("uri")
         if not uri:
             return

--- a/src/tricca_autopipette/core/autopipette.py
+++ b/src/tricca_autopipette/core/autopipette.py
@@ -554,18 +554,6 @@ class AutoPipette:
             f"{GCodeCommand.LINEAR_MOVE} Z{coordinate.z} F{speed_z}\n"
         )
 
-    def move_to_x(self, coordinate: Coordinate) -> None:
-        """Move only in X direction."""
-        speed = self.gantry.speed_xy
-        self.logger.debug("G-code move: X=%s (speed=%s)", coordinate.x, speed)
-        self.gcode_buffers.add(f"{GCodeCommand.LINEAR_MOVE} X{coordinate.x} F{speed}\n")
-
-    def move_to_y(self, coordinate: Coordinate) -> None:
-        """Move only in Y direction."""
-        speed = self.gantry.speed_xy
-        self.logger.debug("G-code move: Y=%s (speed=%s)", coordinate.y, speed)
-        self.gcode_buffers.add(f"{GCodeCommand.LINEAR_MOVE} Y{coordinate.y} F{speed}\n")
-
     def move_to_z(self, coordinate: Coordinate) -> None:
         """Move only in Z direction."""
         speed = self.gantry.speed_z
@@ -652,16 +640,22 @@ class AutoPipette:
         """
         return self.gcode_buffers.get_header()
 
-    def next_tip(self) -> None:
+    def next_tip(self, tipbox_name: str | None = None) -> None:
         """Pick up the next available tip from the configured tipboxes.
 
         Boxes are drawn from in the order they appear in the locations config,
         each in its own traversal order, and a consumed position is never
-        offered again.
+        offered again -- unless `tipbox_name` requests a specific box.
+
+        Args:
+            tipbox_name: If given, draw only from this box instead of the
+                registration-order default.
 
         Raises:
             NoTipboxError: If no tipbox has been configured.
-            OutOfTipsError: If every configured tipbox is exhausted. Reload the
+            NotALocationError: If `tipbox_name` is given but no box is
+                configured under that name.
+            OutOfTipsError: If every tried tipbox is exhausted. Reload the
                 boxes and run ``reset_tips`` rather than reusing a tip.
             TipAlreadyOnError: If a tip is already attached.
         """  # ruff: ignore[docstring-extraneous-exception]
@@ -670,7 +664,9 @@ class AutoPipette:
 
         # The supplying box comes back with the coordinate: boxes may sit at
         # different heights, so the dip distance must come from *that* box.
-        name, box, loc_tip = self.location_manager.tipbox_manager.next_tip()
+        name, box, loc_tip = self.location_manager.tipbox_manager.next_tip(
+            name=tipbox_name
+        )
         self.note_action(
             f"Picking up tip from '{name}' at (X:{loc_tip.x:.2f}, Y:{loc_tip.y:.2f})"
         )
@@ -1247,8 +1243,7 @@ class AutoPipette:
 
         # Pick up tip if needed
         if self.state.tip_state == TipState.DETACHED:
-            _ = tipbox_name
-            self.next_tip()  # TODO: Pass in preferred tipbox
+            self.next_tip(tipbox_name=tipbox_name)
 
         # Calculate transfer chunks based on max pipette capacity. The air
         # gaps ride along inside the same syringe, so they come out of the
@@ -1464,8 +1459,7 @@ class AutoPipette:
         )
 
         if self.state.tip_state == TipState.DETACHED:
-            _ = tipbox_name
-            self.next_tip()  # TODO: Pass in preferred tipbox
+            self.next_tip(tipbox_name=tipbox_name)
 
         destinations = ", ".join(f"{s.dest}:{s.vol_ul:g}μL" for s in splits)
         self.note_action(

--- a/src/tricca_autopipette/core/location_manager.py
+++ b/src/tricca_autopipette/core/location_manager.py
@@ -680,6 +680,12 @@ class LocationManager:
                 either config root.
         """
         parsed: list[tuple[str, PlateParams, set[int] | None]] = []
+        # Several entries commonly share one template (e.g. identical
+        # tipboxes) -- cache each file's parse for the rest of this call so
+        # it's read once, not once per referencing entry. Scoped to this one
+        # call (not persisted on self) since a template edited between two
+        # separate load_from_json calls should be picked up fresh.
+        plate_def_cache: dict[Path, dict[str, Any]] = {}
 
         for entry in locations_data.get("plates", []):
             plate_data = cast("dict[str, Any]", entry)
@@ -694,7 +700,14 @@ class LocationManager:
                     )
                 except FileNotFoundError as e:
                     raise FileNotFoundError(f"Plate definition not found: {e}") from e
-                plate_def = self._load_plate_definition(plate_file_path)
+                if plate_file_path not in plate_def_cache:
+                    plate_def_cache[plate_file_path] = self._load_plate_definition(
+                        plate_file_path
+                    )
+                # Copied so the .update() below (per-entry overrides) can't
+                # mutate the cached template out from under the next entry
+                # that references the same file.
+                plate_def = dict(plate_def_cache[plate_file_path])
                 plate_def.update({
                     key: value
                     for key, value in plate_data.items()

--- a/src/tricca_autopipette/core/tipbox_manager.py
+++ b/src/tricca_autopipette/core/tipbox_manager.py
@@ -187,11 +187,16 @@ class TipBoxManager:
         """
         return sum(box.capacity for box in self.boxes.values())
 
-    def next_tip(self) -> tuple[str, TipBox, Coordinate]:
+    def next_tip(self, name: str | None = None) -> tuple[str, TipBox, Coordinate]:
         """Consume the next tip from the first box that still has one.
 
         Boxes are tried in registration order, so a box is fully drained before
-        the next is touched.
+        the next is touched -- unless a specific box is requested by name, in
+        which case only that box is drawn from.
+
+        Args:
+            name: If given, draw only from this box instead of trying every
+                registered box in order.
 
         Returns:
             Tuple of the supplying box's name, the box itself, and the
@@ -200,7 +205,9 @@ class TipBoxManager:
 
         Raises:
             NoTipboxError: If no tipbox is registered at all.
-            OutOfTipsError: If every registered box is exhausted.
+            NotALocationError: If `name` is given but no box is registered
+                under that name.
+            OutOfTipsError: If every tried box is exhausted.
 
         Example:
             ``name, box, coor = manager.next_tip()`` returns the supplying
@@ -210,12 +217,22 @@ class TipBoxManager:
         if not self.boxes:
             raise NoTipboxError()
 
-        for name, box in self.boxes.items():
+        if name is not None:
+            box = self.boxes.get(name)
+            if box is None:
+                raise NotALocationError(name)
+            try:
+                _index, coor = box.take_tip()
+            except PlateExhaustedError:
+                raise OutOfTipsError([name]) from None
+            return name, box, coor
+
+        for box_name, box in self.boxes.items():
             try:
                 _index, coor = box.take_tip()
             except PlateExhaustedError:
                 continue
-            return name, box, coor
+            return box_name, box, coor
 
         raise OutOfTipsError(list(self.boxes))
 

--- a/src/tricca_autopipette/daemon/control_requests.py
+++ b/src/tricca_autopipette/daemon/control_requests.py
@@ -14,7 +14,6 @@ Example:
 from __future__ import annotations
 
 import dataclasses
-import uuid
 from typing import Any
 
 from tricca_autopipette.commands.tap_cmd_parsers import (
@@ -41,33 +40,11 @@ from tricca_autopipette.commands.tap_cmd_parsers import (
     VolToStepsArgs,
     WaitArgs,
 )
+from tricca_autopipette.moonraker.moonraker_requests import JsonRpcRequestBuilder
 
 
-class ControlRequests:
+class ControlRequests(JsonRpcRequestBuilder):
     """JSON-RPC request builder for the ``tapd`` control-plane protocol."""
-
-    JSON_RPC_VERSION: str = "2.0"
-
-    def gen_request(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Generate a JSON-RPC 2.0 request.
-
-        Args:
-            method: Control-plane method to call.
-            params: Optional parameters dictionary for the method.
-
-        Returns:
-            Dictionary representing the JSON-RPC request.
-        """
-        request: dict[str, Any] = {
-            "jsonrpc": self.JSON_RPC_VERSION,
-            "method": method,
-            "id": str(uuid.uuid4()),
-        }
-        if params is not None:
-            request["params"] = params
-        return request
 
     def init(self) -> dict[str, Any]:
         """Build a request to initialise the pipette.

--- a/src/tricca_autopipette/daemon/control_server.py
+++ b/src/tricca_autopipette/daemon/control_server.py
@@ -15,6 +15,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -43,12 +44,100 @@ from tricca_autopipette.commands.tap_cmd_parsers import (
     VolToStepsArgs,
     WaitArgs,
 )
-from tricca_autopipette.daemon.service import AutoPipetteService, RunStatus
+from tricca_autopipette.daemon.service import (
+    AutoPipetteService,
+    CommandResult,
+    RunStatus,
+)
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+
+
+@dataclasses.dataclass(frozen=True)
+class _RpcCommand:
+    """One entry in the regular-shaped RPC dispatch table.
+
+    Covers every control-plane method whose handling is exactly "build an
+    ``*Args`` dataclass from ``params`` (or take no arguments), dispatch the
+    named ``AutoPipetteService`` method through ``service.dispatch``, and
+    ``dataclasses.asdict`` the ``CommandResult`` it returns" -- the large
+    majority of methods. Methods with any other shape (a bare-value
+    argument instead of an ``*Args`` dataclass, a non-``CommandResult``
+    return, special handling of ``ws``/``self._clients``, ...) are handled
+    as explicit branches in :meth:`ControlServer._call` instead of forced
+    into this table.
+
+    Mirrors ``daemon/service.py``'s ``_LineCommand``/``_LINE_DISPATCH``,
+    which solves the identical "command name -> parser/args -> service
+    method" problem for protocol-file lines -- one shape for both.
+
+    Attributes:
+        args_cls: The ``*Args`` dataclass to build from ``params``, or None
+            for a zero-argument RPC.
+        method: The corresponding *unbound* ``AutoPipetteService`` method
+            (``AutoPipetteService.move``, not a bound instance method) --
+            called as ``method(service_instance, args)`` (or
+            ``method(service_instance)`` when ``args_cls`` is None).
+    """
+
+    args_cls: type | None
+    method: Callable[..., CommandResult]
+
+
+#: Maps a control-plane method name to how to build its args and which
+#: service method to dispatch it to. Built once at import time -- see
+#: :class:`_RpcCommand`'s docstring for the shape this covers and why some
+#: methods are deliberately not listed here.
+_RPC_DISPATCH: dict[str, _RpcCommand] = {
+    "movement.init": _RpcCommand(None, AutoPipetteService.init),
+    "movement.home": _RpcCommand(HomeArgs, AutoPipetteService.home),
+    "movement.move": _RpcCommand(MoveArgs, AutoPipetteService.move),
+    "movement.move_loc": _RpcCommand(MoveLocArgs, AutoPipetteService.move_loc),
+    "movement.move_rel": _RpcCommand(MoveRelArgs, AutoPipetteService.move_rel),
+    "pipette.aspirate": _RpcCommand(AspirateArgs, AutoPipetteService.aspirate),
+    "pipette.dispense": _RpcCommand(DispenseArgs, AutoPipetteService.dispense),
+    "pipette.transfer": _RpcCommand(PipetteArgs, AutoPipetteService.transfer),
+    "pipette.next_tip": _RpcCommand(None, AutoPipetteService.next_tip),
+    "pipette.eject_tip": _RpcCommand(None, AutoPipetteService.eject_tip),
+    "pipette.dispose_tip": _RpcCommand(None, AutoPipetteService.dispose_tip),
+    "pipette.change_tip": _RpcCommand(None, AutoPipetteService.change_tip),
+    "config.set": _RpcCommand(SetArgs, AutoPipetteService.set),
+    "config.coor": _RpcCommand(CoorArgs, AutoPipetteService.coor),
+    "config.plate": _RpcCommand(PlateArgs, AutoPipetteService.plate),
+    "config.reset_plate": _RpcCommand(ResetPlateArgs, AutoPipetteService.reset_plate),
+    "config.reset_plates": _RpcCommand(None, AutoPipetteService.reset_plates),
+    "config.del_loc": _RpcCommand(DelLocArgs, AutoPipetteService.del_loc),
+    "config.clear_locs": _RpcCommand(None, AutoPipetteService.clear_locs),
+    "config.load_locations": _RpcCommand(
+        LoadLocationsArgs, AutoPipetteService.load_locations
+    ),
+    "config.unload_locations": _RpcCommand(
+        UnloadLocationsArgs, AutoPipetteService.unload_locations
+    ),
+    "config.reset_tips": _RpcCommand(ResetTipsArgs, AutoPipetteService.reset_tips),
+    "config.reset_tips_all": _RpcCommand(None, AutoPipetteService.reset_tips_all),
+    "config.set_tips": _RpcCommand(SetTipsArgs, AutoPipetteService.set_tips),
+    "config.tips": _RpcCommand(TipsArgs, AutoPipetteService.tips),
+    "util.wait": _RpcCommand(WaitArgs, AutoPipetteService.wait),
+    "util.trigger": _RpcCommand(TriggerArgs, AutoPipetteService.trigger),
+    "util.gcode_print": _RpcCommand(GcodePrintArgs, AutoPipetteService.gcode_print),
+    "util.webcam_url": _RpcCommand(None, AutoPipetteService.webcam_url),
+    "util.vol_to_steps": _RpcCommand(VolToStepsArgs, AutoPipetteService.vol_to_steps),
+    "ws.status": _RpcCommand(None, AutoPipetteService.ws_status),
+    "ws.ping": _RpcCommand(None, AutoPipetteService.ping_moonraker),
+    "ws.read": _RpcCommand(None, AutoPipetteService.read_message),
+    "ws.read_all": _RpcCommand(None, AutoPipetteService.read_all_messages),
+    "ws.clear_queue": _RpcCommand(None, AutoPipetteService.clear_message_queue),
+    "ws.reconnect": _RpcCommand(None, AutoPipetteService.reconnect_websocket),
+    "ws.query_endstops": _RpcCommand(None, AutoPipetteService.query_endstops),
+    "config.list_locations": _RpcCommand(None, AutoPipetteService.list_locations),
+    "config.list_plates": _RpcCommand(None, AutoPipetteService.list_plates),
+    "config.list_liquids": _RpcCommand(None, AutoPipetteService.list_liquids),
+    "config.system_summary": _RpcCommand(None, AutoPipetteService.system_summary),
+}
 
 
 def _run_status_to_dict(status: RunStatus) -> dict[str, Any]:
@@ -250,65 +339,15 @@ class ControlServer:
                 already active.
             FileNotFoundError: If ``run.start`` names a missing protocol.
         """  # ruff: ignore[docstring-extraneous-exception]
-        if method == "movement.init":
-            return dataclasses.asdict(await self.service.dispatch(self.service.init))
-        if method == "movement.home":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.home(HomeArgs(**params))
+        spec = _RPC_DISPATCH.get(method) if method is not None else None
+        if spec is not None:
+            if spec.args_cls is None:
+                return dataclasses.asdict(
+                    await self.service.dispatch(lambda: spec.method(self.service))
                 )
-            )
-        if method == "movement.move":
+            args = spec.args_cls(**params)
             return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.move(MoveArgs(**params))
-                )
-            )
-        if method == "movement.move_loc":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.move_loc(MoveLocArgs(**params))
-                )
-            )
-        if method == "movement.move_rel":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.move_rel(MoveRelArgs(**params))
-                )
-            )
-        if method == "pipette.aspirate":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.aspirate(AspirateArgs(**params))
-                )
-            )
-        if method == "pipette.dispense":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.dispense(DispenseArgs(**params))
-                )
-            )
-        if method == "pipette.transfer":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.transfer(PipetteArgs(**params))
-                )
-            )
-        if method == "pipette.next_tip":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.next_tip)
-            )
-        if method == "pipette.eject_tip":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.eject_tip)
-            )
-        if method == "pipette.dispose_tip":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.dispose_tip)
-            )
-        if method == "pipette.change_tip":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.change_tip)
+                await self.service.dispatch(lambda: spec.method(self.service, args))
             )
         if method == "config.switch_liquid":
             return dataclasses.asdict(
@@ -322,108 +361,10 @@ class ControlServer:
                     lambda: self.service.load_liquid(params["filename"])
                 )
             )
-        if method == "config.set":
-            return dataclasses.asdict(
-                await self.service.dispatch(lambda: self.service.set(SetArgs(**params)))
-            )
-        if method == "config.coor":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.coor(CoorArgs(**params))
-                )
-            )
-        if method == "config.plate":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.plate(PlateArgs(**params))
-                )
-            )
-        if method == "config.reset_plate":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.reset_plate(ResetPlateArgs(**params))
-                )
-            )
-        if method == "config.reset_plates":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.reset_plates)
-            )
-        if method == "config.del_loc":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.del_loc(DelLocArgs(**params))
-                )
-            )
-        if method == "config.clear_locs":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.clear_locs)
-            )
         if method == "config.save_locations":
             return dataclasses.asdict(
                 await self.service.dispatch(
                     lambda: self.service.save_locations(params["filename"])
-                )
-            )
-        if method == "config.load_locations":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.load_locations(LoadLocationsArgs(**params))
-                )
-            )
-        if method == "config.unload_locations":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.unload_locations(UnloadLocationsArgs(**params))
-                )
-            )
-        if method == "config.reset_tips":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.reset_tips(ResetTipsArgs(**params))
-                )
-            )
-        if method == "config.reset_tips_all":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.reset_tips_all)
-            )
-        if method == "config.set_tips":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.set_tips(SetTipsArgs(**params))
-                )
-            )
-        if method == "config.tips":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.tips(TipsArgs(**params))
-                )
-            )
-        if method == "util.wait":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.wait(WaitArgs(**params))
-                )
-            )
-        if method == "util.trigger":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.trigger(TriggerArgs(**params))
-                )
-            )
-        if method == "util.gcode_print":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.gcode_print(GcodePrintArgs(**params))
-                )
-            )
-        if method == "util.webcam_url":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.webcam_url)
-            )
-        if method == "util.vol_to_steps":
-            return dataclasses.asdict(
-                await self.service.dispatch(
-                    lambda: self.service.vol_to_steps(VolToStepsArgs(**params))
                 )
             )
         if method == "util.steps_to_vol":
@@ -470,14 +411,6 @@ class ControlServer:
                     for client_type in self._clients.values()
                 ]
             }
-        if method == "ws.status":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.ws_status)
-            )
-        if method == "ws.ping":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.ping_moonraker)
-            )
         if method == "ws.send":
             return dataclasses.asdict(
                 await self.service.dispatch(
@@ -513,41 +446,5 @@ class ControlServer:
                         params["file_name"], Path(params["file_path"])
                     )
                 )
-            )
-        if method == "ws.read":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.read_message)
-            )
-        if method == "ws.read_all":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.read_all_messages)
-            )
-        if method == "ws.clear_queue":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.clear_message_queue)
-            )
-        if method == "ws.reconnect":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.reconnect_websocket)
-            )
-        if method == "ws.query_endstops":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.query_endstops)
-            )
-        if method == "config.list_locations":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.list_locations)
-            )
-        if method == "config.list_plates":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.list_plates)
-            )
-        if method == "config.list_liquids":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.list_liquids)
-            )
-        if method == "config.system_summary":
-            return dataclasses.asdict(
-                await self.service.dispatch(self.service.system_summary)
             )
         raise ValueError(f"Unknown method: {method}")

--- a/src/tricca_autopipette/daemon/moonraker_state.py
+++ b/src/tricca_autopipette/daemon/moonraker_state.py
@@ -24,12 +24,17 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from tricca_autopipette.moonraker.moonraker_requests import MoonrakerRequests
-from tricca_autopipette.moonraker.websocket_client import WebSocketClient
+from tricca_autopipette.moonraker.websocket_client import WebSocketClient, as_dict
 
 logger = logging.getLogger(__name__)
 
 #: server.database namespace used to persist tip/liquid state.
 DB_NAMESPACE = "tricca_autopipette"
+
+#: Single key tip/liquid state is stored under, as one combined dict --
+#: one DB round trip instead of one per field (matching DB_KEY_TIP_PRESENCE's
+#: shape below). The three field names inside that dict.
+DB_KEY_TIP_LIQUID_STATE = "tip_liquid_state"
 DB_KEY_TIP_STATE = "tip_state"
 DB_KEY_HAS_LIQUID = "has_liquid"
 DB_KEY_CURRENT_LIQUID = "current_liquid"
@@ -41,21 +46,6 @@ DB_KEY_TIP_PRESENCE = "tip_presence"
 
 #: Axes that must all be reported homed by Klipper for the interlock to pass.
 REQUIRED_HOMED_AXES = frozenset({"x", "y", "z"})
-
-
-def _as_dict(value: Any) -> dict[str, Any]:  # ruff:ignore[any-type]
-    """Narrow a loosely-typed JSON value to a dict, defaulting to empty.
-
-    Args:
-        value: Value to narrow, typically from a JSON-RPC response or
-            notification payload of otherwise unknown shape.
-
-    Returns:
-        ``value`` if it is a dict, otherwise an empty dict.
-    """
-    if isinstance(value, dict):
-        return cast("dict[str, Any]", value)
-    return {}
 
 
 class MoonrakerStateTracker:
@@ -89,8 +79,8 @@ class MoonrakerStateTracker:
         self.client.register_handler("notify_status_update", self._on_status_update)
         request = self.mrr.request_sub_to_objs(["toolhead", "print_stats"])
         response = self.client.send_jsonrpc(request)
-        result = _as_dict(response.get("result"))
-        status = _as_dict(result.get("status"))
+        result = as_dict(response.get("result"))
+        status = as_dict(result.get("status"))
         self._apply_status(status)
 
     def is_homed(self) -> bool:
@@ -128,7 +118,7 @@ class MoonrakerStateTracker:
         if not params:
             return
         candidate = cast("list[Any]", params)[0] if isinstance(params, list) else params
-        status = _as_dict(candidate)
+        status = as_dict(candidate)
         if status:
             self._apply_status(status)
 
@@ -140,7 +130,7 @@ class MoonrakerStateTracker:
                 returned by both ``printer.objects.subscribe``'s initial
                 response and subsequent ``notify_status_update`` pushes.
         """
-        toolhead = _as_dict(status.get("toolhead"))
+        toolhead = as_dict(status.get("toolhead"))
         homed_axes = toolhead.get("homed_axes")
         if isinstance(homed_axes, str):
             self._homed_axes = frozenset(homed_axes)
@@ -149,7 +139,7 @@ class MoonrakerStateTracker:
                 str(axis) for axis in cast("list[Any]", homed_axes)
             )
 
-        print_stats = _as_dict(status.get("print_stats"))
+        print_stats = as_dict(status.get("print_stats"))
         new_state = print_stats.get("state")
         if isinstance(new_state, str) and new_state != self._print_state:
             self._print_state = new_state
@@ -164,18 +154,22 @@ class MoonrakerStateTracker:
         Returns:
             Mapping of the keys that had a stored value (``tip_state``,
             ``has_liquid``, ``current_liquid``) to their stored value.
-            Keys with no prior stored value (e.g. first run) are omitted.
+            Keys with no prior stored value (e.g. first run, or a value
+            persisted before this combined-key format) are omitted.
         """
-        result: dict[str, Any] = {}
-        for key in (DB_KEY_TIP_STATE, DB_KEY_HAS_LIQUID, DB_KEY_CURRENT_LIQUID):
-            try:
-                response = self.client.send_jsonrpc(
-                    self.mrr.server_database_get_item(DB_NAMESPACE, key)
-                )
-                result[key] = response["result"]["value"]
-            except Exception:
-                logger.info("No persisted value for '%s' (first run?)", key)
-        return result
+        try:
+            response = self.client.send_jsonrpc(
+                self.mrr.server_database_get_item(DB_NAMESPACE, DB_KEY_TIP_LIQUID_STATE)
+            )
+            value = response["result"]["value"]
+        except Exception:
+            logger.info("No persisted tip/liquid state (first run?)")
+            return {}
+
+        if not isinstance(value, dict):
+            logger.warning("Persisted tip/liquid state is not a mapping; ignoring")
+            return {}
+        return cast("dict[str, Any]", value)
 
     def save_tip_liquid_state(
         self,
@@ -185,20 +179,26 @@ class MoonrakerStateTracker:
     ) -> None:
         """Persist tip/liquid state to Moonraker's database.
 
+        One combined write rather than one per field -- matching
+        ``save_tip_presence``'s shape below.
+
         Args:
             tip_state: ``TipState`` value (as a string) to store.
             has_liquid: Whether liquid is currently in the tip.
             current_liquid: Name of the currently active liquid profile, or
                 None.
         """
-        for key, value in (
-            (DB_KEY_TIP_STATE, tip_state),
-            (DB_KEY_HAS_LIQUID, has_liquid),
-            (DB_KEY_CURRENT_LIQUID, current_liquid),
-        ):
-            self.client.send_jsonrpc(
-                self.mrr.server_database_post_item(DB_NAMESPACE, key, value)
+        self.client.send_jsonrpc(
+            self.mrr.server_database_post_item(
+                DB_NAMESPACE,
+                DB_KEY_TIP_LIQUID_STATE,
+                {
+                    DB_KEY_TIP_STATE: tip_state,
+                    DB_KEY_HAS_LIQUID: has_liquid,
+                    DB_KEY_CURRENT_LIQUID: current_liquid,
+                },
             )
+        )
 
     def load_tip_presence(self) -> dict[str, Any]:
         """Read persisted per-tipbox consumed-position maps.

--- a/src/tricca_autopipette/moonraker/moonraker_requests.py
+++ b/src/tricca_autopipette/moonraker/moonraker_requests.py
@@ -16,7 +16,54 @@ import uuid
 from typing import Any, ClassVar
 
 
-class MoonrakerRequests:
+class JsonRpcRequestBuilder:
+    """Base envelope builder shared by every JSON-RPC request builder here.
+
+    Both `MoonrakerRequests` (talking to Moonraker itself) and
+    `daemon.control_requests.ControlRequests` (talking to `tapd`'s
+    control plane) build the identical JSON-RPC 2.0 envelope -- the
+    control-plane protocol is deliberately isomorphic to Moonraker's own, so
+    the envelope-building code is shared rather than copy-pasted.
+    """
+
+    # Protocol version
+    JSON_RPC_VERSION: str = "2.0"
+
+    def gen_request(
+        self, method: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Generate a JSON-RPC 2.0 request.
+
+        Args:
+            method: The API method to call.
+            params: Optional parameters dictionary for the method.
+
+        Returns:
+            Dictionary representing the JSON-RPC request with jsonrpc, method,
+            id, and optionally params fields.
+
+        Example:
+            >>> mrr = MoonrakerRequests()
+            >>> request = mrr.gen_request("printer.info")
+            >>> # {'jsonrpc': '2.0', 'method': 'printer.info', 'id': '...'}
+
+            >>> request = mrr.gen_request(
+            ...     "printer.print.start", {"filename": "test.gcode"}
+            ... )
+            >>> # {'jsonrpc': '2.0', 'method': 'printer.print.start', 'id': '...',
+            >>> #  'params': {'filename': 'test.gcode'}}
+        """
+        request: dict[str, Any] = {
+            "jsonrpc": self.JSON_RPC_VERSION,
+            "method": method,
+            "id": str(uuid.uuid4()),
+        }
+        if params is not None:
+            request["params"] = params
+        return request
+
+
+class MoonrakerRequests(JsonRpcRequestBuilder):
     """JSON-RPC request builder for Moonraker API.
 
     Provides type-safe methods for constructing JSON-RPC 2.0 requests for all
@@ -25,7 +72,6 @@ class MoonrakerRequests:
 
     Attributes:
         JSON_RPC_VERSION: JSON-RPC protocol version (always "2.0").
-        METHODS: List of all available Moonraker API methods.
         SUBSCRIBABLE: List of printer objects that support subscriptions.
 
     Example:
@@ -40,143 +86,6 @@ class MoonrakerRequests:
         >>> # Execute G-code
         >>> gcode_request = mrr.printer_gcode_script("G28")
     """
-
-    # Protocol version
-    JSON_RPC_VERSION: str = "2.0"
-
-    # All available Moonraker API methods
-    METHODS: ClassVar[list[str]] = [
-        # Server Administration
-        "server.info",
-        "server.config",
-        "server.temperature_store",
-        "server.gcode_store",
-        "server.logs.rollover",
-        "server.restart",
-        "server.connection.identify",
-        "server.websocket.id",
-        # Printer Administration
-        "printer.info",
-        "printer.emergency_stop",
-        "printer.restart",
-        # Printer Status
-        "printer.objects.list",
-        "printer.objects.query",
-        "printer.objects.subscribe",
-        "printer.query_endstops.status",
-        # GCode API
-        "printer.gcode.script",
-        "printer.gcode.help",
-        # Print Management
-        "printer.print.start",
-        "printer.print.pause",
-        "printer.print.resume",
-        "printer.print.cancel",
-        # Machine Requests
-        "machine.system_info",
-        "machine.shutdown",
-        "machine.reboot",
-        "machine.services.restart",
-        "machine.services.stop",
-        "machine.services.start",
-        "machine.proc_stats",
-        "machine.sudo.info",
-        "machine.sudo.password",
-        "machine.peripherals.usb",
-        "machine.peripherals.serial",
-        "machine.peripherals.video",
-        "machine.peripherals.canbus",
-        # File Operations
-        "server.files.list",
-        "server.files.roots",
-        "server.files.metadata",
-        "server.files.metascan",
-        "server.files.thumbnails",
-        "server.files.get_directory",
-        "server.files.post_directory",
-        "server.files.delete_directory",
-        "server.files.move",
-        "server.files.copy",
-        "server.files.zip",
-        "server.files.delete_file",
-        # Authorization
-        "access.login",
-        "access.logout",
-        "access.get_user",
-        "access.post_user",
-        "access.delete_user",
-        "access.users.list",
-        "access.user.password",
-        "access.refresh_jwt",
-        "access.oneshot_token",
-        "access.info",
-        "access.get_api_key",
-        "access.post_api_key",
-        # History APIs
-        "server.history.list",
-        "server.history.totals",
-        "server.history.reset_totals",
-        "server.history.get_job",
-        "server.history.delete_job",
-        # Database APIs
-        "server.database.list",
-        "server.database.get_item",
-        "server.database.post_item",
-        "server.database.delete_item",
-        "server.database.compact",
-        "server.database.post_backup",
-        "server.database.delete_backup",
-        "server.database.restore",
-        # Job Queue APIs
-        "server.job_queue.status",
-        "server.job_queue.post_job",
-        "server.job_queue.delete_job",
-        "server.job_queue.pause",
-        "server.job_queue.start",
-        "server.job_queue.jump",
-        # Announcement APIs
-        "server.announcements.list",
-        "server.announcements.update",
-        "server.announcements.dismiss",
-        "server.announcements.feeds",
-        "server.announcements.post_feed",
-        "server.announcements.delete_feed",
-        # Webcam APIs
-        "server.webcams.list",
-        "server.webcams.get_item",
-        "server.webcams.post_item",
-        "server.webcams.delete_item",
-        "server.webcams.test",
-        # Notifier APIs
-        "server.notifiers.list",
-        # Update Manager APIs
-        "machine.update.status",
-        "machine.update.refresh",
-        "machine.update.full",
-        "machine.update.moonraker",
-        "machine.update.klipper",
-        "machine.update.client",
-        "machine.update.system",
-        "machine.update.recover",
-        "machine.update.rollback",
-        # Power APIs
-        "machine.device_power.devices",
-        "machine.device_power.get_device",
-        "machine.device_power.post_device",
-        "machine.device_power.status",
-        "machine.device_power.on",
-        "machine.device_power.off",
-        # WLED APIs
-        "machine.wled.strips",
-        "machine.wled.status",
-        "machine.wled.on",
-        "machine.wled.off",
-        "machine.wled.toggle",
-        # Sensor APIs
-        "server.sensors.list",
-        "server.sensors.info",
-        "server.sensors.measurements",
-    ]
 
     # Printer objects available for subscription
     SUBSCRIBABLE: ClassVar[list[str]] = [
@@ -227,39 +136,6 @@ class MoonrakerRequests:
         "z_thermal_adjust",
         "z_tilt",
     ]
-
-    def gen_request(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        """Generate a JSON-RPC 2.0 request.
-
-        Args:
-            method: The Moonraker API method to call.
-            params: Optional parameters dictionary for the method.
-
-        Returns:
-            Dictionary representing the JSON-RPC request with jsonrpc, method,
-            id, and optionally params fields.
-
-        Example:
-            >>> mrr = MoonrakerRequests()
-            >>> request = mrr.gen_request("printer.info")
-            >>> # {'jsonrpc': '2.0', 'method': 'printer.info', 'id': '...'}
-
-            >>> request = mrr.gen_request(
-            ...     "printer.print.start", {"filename": "test.gcode"}
-            ... )
-            >>> # {'jsonrpc': '2.0', 'method': 'printer.print.start', 'id': '...',
-            >>> #  'params': {'filename': 'test.gcode'}}
-        """
-        request: dict[str, Any] = {
-            "jsonrpc": self.JSON_RPC_VERSION,
-            "method": method,
-            "id": str(uuid.uuid4()),
-        }
-        if params is not None:
-            request["params"] = params
-        return request
 
     def request_sub_to_objs(self, objs: list[str]) -> dict[str, Any]:
         """Create subscription request for printer objects.

--- a/src/tricca_autopipette/moonraker/websocket_client.py
+++ b/src/tricca_autopipette/moonraker/websocket_client.py
@@ -44,11 +44,68 @@ from enum import StrEnum
 from pathlib import Path
 from queue import Empty, Queue
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp import ClientSession, ClientWebSocketResponse, FormData, WSMsgType
+
+
+def as_dict(value: Any) -> dict[str, Any]:  # ruff:ignore[any-type]
+    """Narrow a loosely-typed JSON value to a dict, defaulting to empty.
+
+    Shared by every client that parses a JSON-RPC result/params/notification
+    payload of otherwise unknown shape over this module's `WebSocketClient`
+    -- the control-plane envelope is deliberately isomorphic to Moonraker's
+    own, so this narrowing helper is too.
+
+    Args:
+        value: Value to narrow, typically from a JSON-RPC response or
+            notification payload of otherwise unknown shape.
+
+    Returns:
+        ``value`` if it is a dict, otherwise an empty dict.
+    """
+    if isinstance(value, dict):
+        return cast("dict[str, Any]", value)
+    return {}
+
+
+class JsonRpcError(RuntimeError):
+    """Raised when a JSON-RPC response carries an ``"error"`` field.
+
+    A subclass of `RuntimeError` so every existing ``except RuntimeError``
+    call site keeps working unchanged; callers that need more than the
+    flattened message string (e.g. to branch on which daemon-side exception
+    was raised) can read `error_type` instead of parsing `str(exc)`.
+
+    Attributes:
+        error: The raw ``error`` payload, e.g. tapd control-plane's
+            ``{"type": "RunAlreadyActiveError", "message": "..."}``
+            (see ``daemon/control_server.py``) or Moonraker's own
+            ``{"code": ..., "message": ...}``.
+    """
+
+    def __init__(self, error: dict[str, Any]) -> None:
+        """Initialize with the raw error payload.
+
+        Args:
+            error: The JSON-RPC response's ``"error"`` field.
+        """
+        self.error = error
+        super().__init__(f"Server error: {error}")
+
+    @property
+    def error_type(self) -> str | None:
+        """The daemon-side exception class name, if the error carries one.
+
+        Returns:
+            tapd control-plane errors carry a ``"type"`` key (the raising
+            exception's class name); Moonraker's own errors don't, so this
+            is None for those.
+        """
+        value = self.error.get("type")
+        return value if isinstance(value, str) else None
 
 
 class MessageType(StrEnum):
@@ -553,9 +610,13 @@ class WebSocketClient:
                             self.logger.warning(
                                 "Server error for request %s: %s", msg_id, data["error"]
                             )
-                            fut.set_exception(
-                                RuntimeError(f"Server error: {data['error']}")
+                            raw_error = data["error"]
+                            error: dict[str, Any] = (
+                                cast("dict[str, Any]", raw_error)
+                                if isinstance(raw_error, dict)
+                                else {"message": str(raw_error)}
                             )
+                            fut.set_exception(JsonRpcError(error))
                         else:
                             self.logger.debug(f"Received response for request {msg_id}")
                             fut.set_result(data)
@@ -657,6 +718,7 @@ class WebSocketClient:
         Raises:
             RuntimeError: If WebSocket is not connected.
             TimeoutError: If response not received within timeout.
+            JsonRpcError: If the response carries an ``"error"`` field.
 
         Example:
             Requires a reachable Moonraker server, so this is illustrative
@@ -690,6 +752,13 @@ class WebSocketClient:
             raise TimeoutError(
                 f"Timed out waiting for response to method '{method}'"
             ) from None
+        except JsonRpcError:
+            # Already a well-formed, structured error from the server itself
+            # (see _process_message) -- let it propagate as-is rather than
+            # flattening it into the generic "unexpected error" case below,
+            # which would erase error_type for callers that branch on it.
+            self._pending.pop(request_id, None)
+            raise
         except Exception as e:
             self._pending.pop(request_id, None)
             self.logger.error("Error sending JSON-RPC: %s", e, exc_info=True)

--- a/tests/cli/test_remote_shell.py
+++ b/tests/cli/test_remote_shell.py
@@ -312,9 +312,7 @@ class TestBreakpointFlow:
 class TestStructuredCommands:
     """One passing and one failing round trip through a hand-written `do_*`."""
 
-    def test_wait_dispatches_through_the_handler(
-        self, shell: RemoteTapShell
-    ) -> None:
+    def test_wait_dispatches_through_the_handler(self, shell: RemoteTapShell) -> None:
         shell.onecmd_plus_hooks("wait 5")
 
         assert "Wait: 5 ms" in _output(shell)

--- a/tests/core/test_autopipette.py
+++ b/tests/core/test_autopipette.py
@@ -21,6 +21,8 @@ from tricca_autopipette.core.pipette_exceptions import (
     VolumeCapacityError,
 )
 from tricca_autopipette.core.pipette_models import TipState
+from tricca_autopipette.core.plates import PlateParams
+from tricca_autopipette.core.well import StrategyType, Well
 
 
 class TestSwitchLiquid:
@@ -142,6 +144,33 @@ class TestTipHandling:
         pipette_with_plates.dispose_tip()
 
         assert pipette_with_plates.state.tip_state == TipState.DETACHED
+
+    def test_next_tip_with_tipbox_name_draws_from_that_box(
+        self, pipette_with_plates: AutoPipette
+    ) -> None:
+        """A caller can request a specific box instead of registration order."""
+        location_manager = pipette_with_plates.location_manager
+        location_manager.set_plate(
+            "tipbox2",
+            PlateParams(
+                plate_type="tipbox",
+                well_template=Well(
+                    coor=Coordinate(x=200.0, y=10.0, z=5.0),
+                    dip_top=5.0,
+                    strategy_type=StrategyType.SIMPLE,
+                ),
+                num_row=1,
+                num_col=2,
+                spacing_row=0.0,
+                spacing_col=9.0,
+            ),
+        )
+
+        pipette_with_plates.next_tip(tipbox_name="tipbox2")
+
+        tipbox_manager = location_manager.tipbox_manager
+        assert tipbox_manager.boxes["tipbox2"].remaining == 1
+        assert tipbox_manager.boxes["tipbox"].remaining == 2
 
 
 class TestAspirateDispenseVolume:

--- a/tests/core/test_location_manager.py
+++ b/tests/core/test_location_manager.py
@@ -720,6 +720,58 @@ class TestPlateFileReference:
         assert entry["dip_btm"] == 11.0  # ruff:ignore[float-equality-comparison]
         assert entry["well_diameter"] == 6.86  # ruff:ignore[float-equality-comparison]
 
+    def test_two_entries_sharing_a_plate_file_read_it_once(
+        self,
+        manager: LocationManager,
+        locations_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Redundant disk reads/JSON parses of one shared template are wasted."""
+        _write(
+            locations_dir,
+            "t.json",
+            {
+                "plates": [
+                    {
+                        "name": "assay_a",
+                        "plate_file": "96_well_standard.json",
+                        "x": 100.0,
+                        "y": 20.0,
+                        "z": 5.0,
+                    },
+                    {
+                        "name": "assay_b",
+                        "plate_file": "96_well_standard.json",
+                        "x": 200.0,
+                        "y": 20.0,
+                        "z": 5.0,
+                    },
+                ]
+            },
+        )
+        calls = 0
+        original = LocationManager._load_plate_definition
+
+        def _counting_load(self: LocationManager, plate_file: Path) -> dict[str, Any]:
+            nonlocal calls
+            calls += 1
+            return original(self, plate_file)
+
+        monkeypatch.setattr(LocationManager, "_load_plate_definition", _counting_load)
+
+        manager.load_from_json("t.json")
+
+        assert calls == 1
+        # Each entry's own placement overrides survive -- the cached template
+        # dict must not have been mutated in place by the first entry's
+        # override before the second entry copied it.
+        plate_a = manager.locations["assay_a"]
+        plate_b = manager.locations["assay_b"]
+        assert isinstance(plate_a, Plate)
+        assert isinstance(plate_b, Plate)
+        assert plate_a.wells[0].coor.x == 100.0  # ruff:ignore[float-equality-comparison]
+        assert plate_b.wells[0].coor.x == 200.0  # ruff:ignore[float-equality-comparison]
+
 
 class TestPlateFileErrors:
     def test_missing_plate_file_raises(

--- a/tests/core/test_tipbox_manager.py
+++ b/tests/core/test_tipbox_manager.py
@@ -183,6 +183,28 @@ class TestDrawing:
         manager.unregister("tips_b")
         assert manager.remaining == 2
 
+    def test_next_tip_with_name_draws_from_that_box(
+        self, manager: TipBoxManager
+    ) -> None:
+        """A caller can request a specific box instead of registration order."""
+        name, box, _coor = manager.next_tip(name="tips_b")
+        assert name == "tips_b"
+        assert box is manager.boxes["tips_b"]
+        assert manager.boxes["tips_a"].remaining == 3
+
+    def test_next_tip_with_unknown_name_raises(self, manager: TipBoxManager) -> None:
+        with pytest.raises(NotALocationError):
+            manager.next_tip(name="nope")
+
+    def test_next_tip_with_name_exhausted_raises_out_of_tips(
+        self, manager: TipBoxManager
+    ) -> None:
+        for _ in range(3):
+            manager.next_tip(name="tips_a")
+        with pytest.raises(OutOfTipsError) as excinfo:
+            manager.next_tip(name="tips_a")
+        assert excinfo.value.boxes == ["tips_a"]
+
 
 # ==================== Resetting ====================
 

--- a/tests/daemon/test_moonraker_state.py
+++ b/tests/daemon/test_moonraker_state.py
@@ -13,6 +13,7 @@ from fakes.fake_websocket_client import FakeWebSocketClient
 from tricca_autopipette.daemon.moonraker_state import (
     DB_KEY_CURRENT_LIQUID,
     DB_KEY_HAS_LIQUID,
+    DB_KEY_TIP_LIQUID_STATE,
     DB_KEY_TIP_PRESENCE,
     DB_KEY_TIP_STATE,
     DB_NAMESPACE,
@@ -212,12 +213,18 @@ class TestPrintStateCallbacks:
 
 
 class TestLoadTipLiquidState:
-    def test_returns_all_three_keys_when_all_are_stored(
+    def test_returns_all_three_keys_when_stored(
         self, fake_websocket_client: FakeWebSocketClient
     ) -> None:
-        fake_websocket_client.queue_response({"result": {"value": "attached"}})
-        fake_websocket_client.queue_response({"result": {"value": True}})
-        fake_websocket_client.queue_response({"result": {"value": "water"}})
+        fake_websocket_client.queue_response({
+            "result": {
+                "value": {
+                    DB_KEY_TIP_STATE: "attached",
+                    DB_KEY_HAS_LIQUID: True,
+                    DB_KEY_CURRENT_LIQUID: "water",
+                }
+            }
+        })
         tracker = _tracker(fake_websocket_client)
 
         result = tracker.load_tip_liquid_state()
@@ -227,23 +234,17 @@ class TestLoadTipLiquidState:
             DB_KEY_HAS_LIQUID: True,
             DB_KEY_CURRENT_LIQUID: "water",
         }
-        methods = [r["method"] for r in fake_websocket_client.sent_requests]
-        assert methods == ["server.database.get_item"] * 3
-        keys = [r["params"]["key"] for r in fake_websocket_client.sent_requests]
-        assert keys == [DB_KEY_TIP_STATE, DB_KEY_HAS_LIQUID, DB_KEY_CURRENT_LIQUID]
-        assert all(
-            r["params"]["namespace"] == DB_NAMESPACE
-            for r in fake_websocket_client.sent_requests
-        )
+        requests = fake_websocket_client.sent_requests
+        assert [r["method"] for r in requests] == ["server.database.get_item"]
+        assert requests[0]["params"]["key"] == DB_KEY_TIP_LIQUID_STATE
+        assert requests[0]["params"]["namespace"] == DB_NAMESPACE
 
-    def test_omits_keys_with_no_stored_value(
+    def test_first_run_with_nothing_stored_returns_empty(
         self, fake_websocket_client: FakeWebSocketClient
     ) -> None:
-        # First run: none of the three keys have ever been persisted, so
-        # Moonraker's `get_item` response lacks the shape `load_tip_liquid_state`
-        # expects, and each lookup falls into the `except` branch.
-        fake_websocket_client.queue_response({})
-        fake_websocket_client.queue_response({})
+        # First run: the key has never been persisted, so Moonraker's
+        # `get_item` response lacks the shape `load_tip_liquid_state`
+        # expects, and the lookup falls into the `except` branch.
         fake_websocket_client.queue_response({})
         tracker = _tracker(fake_websocket_client)
 
@@ -251,24 +252,21 @@ class TestLoadTipLiquidState:
 
         assert result == {}
 
-    def test_partial_state_when_only_some_keys_are_stored(
+    def test_non_mapping_value_is_ignored(
         self, fake_websocket_client: FakeWebSocketClient
     ) -> None:
-        fake_websocket_client.queue_response({"result": {"value": "attached"}})
-        fake_websocket_client.queue_response({})  # has_liquid never stored
-        fake_websocket_client.queue_response({"result": {"value": "water"}})
+        # A stored value from before this key existed in this shape, or any
+        # other malformed record, must not raise or be handed onward.
+        fake_websocket_client.queue_response({"result": {"value": "not-a-dict"}})
         tracker = _tracker(fake_websocket_client)
 
         result = tracker.load_tip_liquid_state()
 
-        assert result == {
-            DB_KEY_TIP_STATE: "attached",
-            DB_KEY_CURRENT_LIQUID: "water",
-        }
+        assert result == {}
 
 
 class TestSaveTipLiquidState:
-    def test_sends_one_post_item_per_key_in_order(
+    def test_sends_one_post_item_for_all_three_fields(
         self, fake_websocket_client: FakeWebSocketClient
     ) -> None:
         tracker = _tracker(fake_websocket_client)
@@ -276,14 +274,14 @@ class TestSaveTipLiquidState:
         tracker.save_tip_liquid_state("attached", True, "water")
 
         requests = fake_websocket_client.sent_requests
-        assert [r["method"] for r in requests] == ["server.database.post_item"] * 3
-        assert [r["params"]["key"] for r in requests] == [
-            DB_KEY_TIP_STATE,
-            DB_KEY_HAS_LIQUID,
-            DB_KEY_CURRENT_LIQUID,
-        ]
-        assert [r["params"]["value"] for r in requests] == ["attached", True, "water"]
-        assert all(r["params"]["namespace"] == DB_NAMESPACE for r in requests)
+        assert [r["method"] for r in requests] == ["server.database.post_item"]
+        assert requests[0]["params"]["key"] == DB_KEY_TIP_LIQUID_STATE
+        assert requests[0]["params"]["namespace"] == DB_NAMESPACE
+        assert requests[0]["params"]["value"] == {
+            DB_KEY_TIP_STATE: "attached",
+            DB_KEY_HAS_LIQUID: True,
+            DB_KEY_CURRENT_LIQUID: "water",
+        }
 
     def test_current_liquid_none_is_persisted_as_none(
         self, fake_websocket_client: FakeWebSocketClient
@@ -293,7 +291,7 @@ class TestSaveTipLiquidState:
         tracker.save_tip_liquid_state("none", False, None)
 
         requests = fake_websocket_client.sent_requests
-        assert requests[2]["params"]["value"] is None
+        assert requests[0]["params"]["value"][DB_KEY_CURRENT_LIQUID] is None
 
 
 class TestLoadTipPresence:

--- a/tests/kiosk/browser/test_tips_toggle.py
+++ b/tests/kiosk/browser/test_tips_toggle.py
@@ -12,17 +12,29 @@ client-side class toggle -- a client-only assertion could pass while
 
 from __future__ import annotations
 
+import json
 import re
+import urllib.request
+from typing import Any
 
 import pytest
 
 pytest.importorskip("playwright")
 
-import requests
 from playwright.sync_api import Page, expect
 from support.live_kiosk_server import LiveKioskServer
 
 PRESENT = re.compile(r"\bpresent\b")
+
+
+def _get_json(url: str) -> Any:
+    """GET `url` and parse the JSON body. Stdlib stand-in for `requests.get`.
+
+    Returns:
+        The parsed JSON body.
+    """
+    with urllib.request.urlopen(url, timeout=5) as response:
+        return json.load(response)
 
 
 def test_tapping_a_present_cell_marks_it_consumed_end_to_end(
@@ -48,9 +60,7 @@ def test_tapping_a_present_cell_marks_it_consumed_end_to_end(
     # cell" from "toggled the wrong one and re-rendered anyway" -- confirm
     # against the server's own record, the same `GET /tips` tips.js itself
     # polls after every toggle.
-    listing = requests.get(
-        f"{live_kiosk_server_with_plates.url}/tips", timeout=5
-    ).json()
+    listing = _get_json(f"{live_kiosk_server_with_plates.url}/tips")
     assert listing["data"]["boxes"][0]["present"] == [False, True]
 
 
@@ -67,9 +77,7 @@ def test_tapping_again_restores_it(
     card.locator('.tip-cell[data-index="0"]').click()
     expect(card.locator('.tip-cell[data-index="0"]')).to_have_class(PRESENT)
 
-    listing = requests.get(
-        f"{live_kiosk_server_with_plates.url}/tips", timeout=5
-    ).json()
+    listing = _get_json(f"{live_kiosk_server_with_plates.url}/tips")
     assert listing["data"]["boxes"][0]["present"] == [True, True]
 
 

--- a/tests/moonraker/test_moonraker_requests.py
+++ b/tests/moonraker/test_moonraker_requests.py
@@ -782,7 +782,7 @@ def test_builder_call_table_matches_moonraker_requests_exactly() -> None:
         name
         for name in dir(MoonrakerRequests)
         if not name.startswith("_")
-        and name not in ("JSON_RPC_VERSION", "METHODS", "SUBSCRIBABLE", "gen_request")
+        and name not in ("JSON_RPC_VERSION", "SUBSCRIBABLE", "gen_request")
     }
     covered = {row[0] for row in _BUILDER_CALLS}
 
@@ -931,10 +931,7 @@ class TestDeviceGroupHelpers:
 
 
 class TestMethodRegistries:
-    """`METHODS`/`SUBSCRIBABLE` are plain data, but shouldn't silently rot."""
-
-    def test_methods_list_has_no_duplicates(self) -> None:
-        assert len(MoonrakerRequests.METHODS) == len(set(MoonrakerRequests.METHODS))
+    """`SUBSCRIBABLE` is plain data, but shouldn't silently rot."""
 
     def test_subscribable_list_has_no_duplicates(self) -> None:
         assert len(MoonrakerRequests.SUBSCRIBABLE) == len(

--- a/tests/moonraker/test_websocket_client.py
+++ b/tests/moonraker/test_websocket_client.py
@@ -30,7 +30,11 @@ import pytest
 import websockets
 from websockets.exceptions import ConnectionClosed
 
-from tricca_autopipette.moonraker.websocket_client import MessageType, WebSocketClient
+from tricca_autopipette.moonraker.websocket_client import (
+    JsonRpcError,
+    MessageType,
+    WebSocketClient,
+)
 
 Handler = Callable[[websockets.WebSocketServerProtocol], Awaitable[None]]
 ServerFactory = Callable[[Handler], str]
@@ -202,6 +206,49 @@ class TestConcurrentRequests:
             assert set(results) == set(range(20))
             for n, response in results.items():
                 assert response["result"]["echo"] == {"n": n}
+        finally:
+            client.stop()
+
+
+class TestErrorResponse:
+    """An `"error"` JSON-RPC response must surface as a `JsonRpcError`.
+
+    Regression coverage for a bug where `send_jsonrpc`'s own broad
+    `except Exception` re-wrapped the structured `JsonRpcError` (raised from
+    `_process_message`) into a plain `RuntimeError`, erasing `error_type` --
+    the kiosk's `/run` endpoint depends on that surviving intact to map a
+    `RunAlreadyActiveError`/`FileNotFoundError` to the right HTTP status.
+    """
+
+    def test_error_response_raises_json_rpc_error_with_type_preserved(
+        self, real_server: ServerFactory
+    ) -> None:
+        async def handler(websocket: websockets.WebSocketServerProtocol) -> None:
+            async for raw in websocket:
+                data = json.loads(raw)
+                await websocket.send(
+                    json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": data["id"],
+                        "error": {
+                            "type": "RunAlreadyActiveError",
+                            "message": "A protocol is already running: a.pipette",
+                        },
+                    })
+                )
+
+        url = real_server(handler)
+        client = WebSocketClient(url)
+        client.start()
+        try:
+            assert client.wait_for_connection(timeout=5)
+
+            with pytest.raises(JsonRpcError) as excinfo:
+                client.send_jsonrpc(
+                    {"jsonrpc": "2.0", "method": "run.start", "id": "1"}, timeout=5.0
+                )
+
+            assert excinfo.value.error_type == "RunAlreadyActiveError"
         finally:
             client.stop()
 


### PR DESCRIPTION
Stacked on #82 (branched from its tip). Requested via /thermo-nuclear-code-quality-review + /improve-codebase-architecture (neither skill was actually available in-session, so this ran as ponytail-audit + /code-review high instead, both approved by the user before applying).

## ponytail-audit findings
- Drop unused `opencv-python`/`requests` main dependencies — zero real use in `src/`; the one test using `requests` now uses stdlib `urllib.request`.
- Delete dead `MoonrakerRequests.METHODS` — an unused 40-line constant list.

## code-review findings (high effort, src/)
- **Real bug fix**: `pipette()`/`pipette_splits()`'s `tipbox_name` flag was parsed end-to-end (CLI → RPC → dataclass) but silently discarded (`_ = tipbox_name  # TODO`). `TipBoxManager.next_tip(name=...)` and `AutoPipette.next_tip(tipbox_name=...)` now honor it. TDD: new tests in `test_tipbox_manager.py`/`test_autopipette.py`.
- Dedupe a triplicated `_as_dict` JSON-narrowing helper (`moonraker_state.py`, `remote_shell.py`, inline in kiosk `main.py`) into one `websocket_client.as_dict()`.
- `save_tip_liquid_state`: 3 DB round trips → 1, storing `tip_state`/`has_liquid`/`current_liquid` under one combined `tip_liquid_state` key (matches `save_tip_presence`'s shape). Old 3-key data is orphaned on upgrade — a one-time reset, approved by the user rather than adding migration code.
- Share `ControlRequests`/`MoonrakerRequests`' duplicated `gen_request` envelope-builder via a new `JsonRpcRequestBuilder` base class.
- Replace `control_server.py`'s ~300-line/62-branch if/elif RPC router with a `{method: (args_cls, service_fn)}` dispatch table for the ~40 regular-shaped methods (mirrors `service.py`'s existing `_LINE_DISPATCH` pattern), keeping the genuinely irregular ones (bare-value args, `run.*`, `daemon.*`, `ws.send`/`notify`/...) as explicit branches.
- Kiosk: replace regex error-type scraping (`_ERROR_TYPE_RE`) with a real `JsonRpcError` exception carrying `.error_type`. Root-cause fix found along the way: `send_jsonrpc`'s own broad `except Exception` was re-wrapping the structured `JsonRpcError` back into a plain `RuntimeError`, erasing the type — fixed with a regression test at the `websocket_client` seam.
- Delete dead `AutoPipette.move_to_x`/`move_to_y` (zero callers anywhere).
- Cache each `plate_file` template's parse within one `_parse_plates()` call instead of re-reading/re-parsing it once per referencing location entry, with a test proving no cross-entry mutation via the cache.

## Skipped (flagged to the user, not applied)
- `TipBoxManager.snapshot()`'s O(n²) rebuild-everything-to-diff pattern after every `next_tip`/`transfer` — a real fix needs dirty-tracking state across every mutating method; worst case (a 384-well box) is still microseconds in absolute terms.
- Kiosk's per-request protocol directory glob (`GET /protocols` + `POST /run`'s 404 pre-check each glob independently) — a cache adds invalidation complexity for a glob over a handful of files, and conflicts with the module's existing "always re-read live" design choice (`AUTOPIPETTE_PROTOCOLS_DIR` already requires a process restart to pick up).

## Verification
`pytest`: 1081 passed (1 pre-existing, unrelated failure deselected — `docs/protocol-command-reference.md` freshness check, confirmed failing on `main` before this branch too, env-dependent argparse wrap width). `ruff check`/`ruff format`: clean. `pyright`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUFvykkGJhRNoe2apfHYqS